### PR TITLE
Feat: configurable kubectl timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,14 @@ MCP Kubernetes Server
 
 options:
   -h, --help            show this help message and exit
-  --disable-kubectl     Disable kubectl command execution
   --disable-helm        Disable helm command execution
   --transport {stdio,sse}
                         Transport mechanism to use (stdio or sse)
   --port PORT           Port to use for the server (only used with sse transport)
+  --readonly            Enable read-only mode (prevents write operations)
+  --allow-namespaces ALLOW_NAMESPACES
+                        Comma-separated list of namespaces to allow (empty means all allowed)
+  --timeout TIMEOUT     Timeout for command execution in seconds, default is 60s
 ```
 
 ## Usage

--- a/src/mcp_kubernetes/command.py
+++ b/src/mcp_kubernetes/command.py
@@ -3,6 +3,7 @@ import logging
 import subprocess
 from typing import List, Union
 
+from .config import config
 from .security_validator import (
     HELM_READ_OPERATIONS,
     KUBECTL_READ_OPERATIONS,
@@ -50,7 +51,10 @@ class ShellProcess:
                 input=input,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                timeout=config.timeout,
             ).stdout.decode()
+        except subprocess.TimeoutExpired:
+            return f"Command execution timed out after {config.timeout} seconds"
         except subprocess.CalledProcessError as error:
             if self.return_err_output:
                 return error.stdout.decode()

--- a/src/mcp_kubernetes/config.py
+++ b/src/mcp_kubernetes/config.py
@@ -1,0 +1,10 @@
+from mcp_kubernetes.security import SecurityConfig
+
+
+class Config:
+    def __init__(self):
+        self.timeout: int = 60
+        self.security_config = SecurityConfig()
+
+
+config = Config()

--- a/src/mcp_kubernetes/security.py
+++ b/src/mcp_kubernetes/security.py
@@ -104,6 +104,3 @@ class SecurityConfig:
                 return True
 
         return False
-
-
-security_config = SecurityConfig()

--- a/src/mcp_kubernetes/security_validator.py
+++ b/src/mcp_kubernetes/security_validator.py
@@ -91,10 +91,12 @@ def validate_readonly(command: str, read_operations: List[str]) -> Optional[str]
     Returns an error message string if validation fails, None if validation passes.
     """
     # Import here to avoid circular import
-    from .security import security_config
+    from .config import config
 
     # Check if we're in readonly mode and if this is a write operation
-    if security_config.readonly and not is_read_operation(command, read_operations):
+    if config.security_config.readonly and not is_read_operation(
+        command, read_operations
+    ):
         return "Error: Cannot execute write operations in read-only mode"
 
     return None
@@ -107,18 +109,18 @@ def validate_namespace_scope(command: str) -> Optional[str]:
     Returns an error message string if validation fails, None if validation passes.
     """
     # Import here to avoid circular import
-    from .security import security_config
+    from .config import config
 
     # Extract namespace from command
     namespace = extract_namespace_from_command(command)
 
     # If command applies to all namespaces (--all-namespaces or -A), and there are namespace restrictions
-    if namespace == "*" and security_config.allowed_namespaces:
+    if namespace == "*" and config.security_config.allowed_namespaces:
         return "Error: Access to all namespaces is restricted by security configuration"
 
     # If a namespace is specified (or default "default" is used), check if it's allowed
     if namespace and namespace != "*":
-        if not security_config.is_namespace_allowed(namespace):
+        if not config.security_config.is_namespace_allowed(namespace):
             return f"Error: Access to namespace '{namespace}' is denied by security configuration"
 
     return None


### PR DESCRIPTION
This pull request introduces a new configuration system for the MCP Kubernetes Server, centralizing settings like timeout and security configurations into a `Config` class. It also adds a timeout feature for command execution and improves the handling of read-only and namespace restrictions. Below are the most important changes grouped by theme:

### Configuration Centralization:
* Introduced a `Config` class in `src/mcp_kubernetes/config.py` to manage global configurations, including `timeout` and `security_config`. This replaces scattered configuration variables.

### Timeout Feature:
* Added a `--timeout` argument to the server command-line interface in `src/mcp_kubernetes/main.py`, allowing users to specify a timeout for command execution. Default is 60 seconds.
* Updated the `exec` method in `src/mcp_kubernetes/command.py` to use the `timeout` value from the `Config` class and handle `TimeoutExpired` exceptions by returning an appropriate error message.

### Command-Line Interface Updates:
* Enhanced the CLI in `README.md` and `src/mcp_kubernetes/main.py` with new options: `--readonly`, `--allow-namespaces`, and `--timeout`, providing more flexibility in server configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R123) [[2]](diffhunk://#diff-fb97f38ae7ea7423be3b4ba9674ecc7142b54236b532844e1675ec861f08c022R76-R95)

These changes improve the maintainability, flexibility, and robustness of the MCP Kubernetes Server.