### PR TITLE
Feat: add streamable-http support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ Command line arguments:
 Usage of ./mcp-kubernetes:
       --additional-tools string   Comma-separated list of additional tools to support (kubectl is always enabled). Available: helm,cilium
       --allow-namespaces string   Comma-separated list of namespaces to allow (empty means all allowed)
-      --port int                  Port to use for the server (only used with sse transport) (default 8000)
+      --host string               Host to listen for the server (only used with transport sse or streamable-http) (default "127.0.0.1")
+      --port int                  Port to listen for the server (only used with transport sse or streamable-http) (default 8000)
       --readonly                  Enable read-only mode (prevents write operations)
       --timeout int               Timeout for command execution in seconds, default is 60s (default 60)
-      --transport string          Transport mechanism to use (stdio or sse) (default "stdio")
+      --transport string          Transport mechanism to use (stdio, sse or streamable-http) (default "stdio")
 ```
 
 ## Usage

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type ConfigData struct {
 
 	// Command-line specific options
 	Transport       string
+	Host            string
 	Port            int
 	ReadOnly        bool
 	AllowNamespaces string
@@ -39,8 +40,9 @@ func NewConfig() *ConfigData {
 // ParseFlags parses command line arguments and updates the configuration
 func (cfg *ConfigData) ParseFlags() {
 	// Server configuration
-	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport mechanism to use (stdio or sse)")
-	flag.IntVar(&cfg.Port, "port", 8000, "Port to use for the server (only used with sse transport)")
+	flag.StringVar(&cfg.Transport, "transport", "stdio", "Transport mechanism to use (stdio, sse or streamable-http)")
+	flag.StringVar(&cfg.Host, "host", "127.0.0.1", "Host to listen for the server (only used with transport sse or streamable-http)")
+	flag.IntVar(&cfg.Port, "port", 8000, "Port to listen for the server (only used with transport sse or streamable-http)")
 	flag.IntVar(&cfg.Timeout, "timeout", 60, "Timeout for command execution in seconds, default is 60s")
 
 	// Tools configuration

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,9 +29,6 @@ func NewService(cfg *config.ConfigData) *Service {
 // Initialize initializes the service
 func (s *Service) Initialize() error {
 	// Initialize configuration
-	if s.cfg.Host == "" {
-		s.cfg.Host = "127.0.0.1"
-	}
 
 	// Create MCP server
 	s.mcpServer = server.NewMCPServer(


### PR DESCRIPTION
Introduce support for the streamable-http transport mechanism, allowing the server to listen on a specified host and port. Update command-line arguments and configuration to accommodate this new transport option.