### PR TITLE
feat: consolidate tools and reduce total number of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Get your kubeconfig file for your Kubernetes cluster and setup in the mcpServers
         "run",
         "-i",
         "--rm",
-        "--mount", "type=bind,src=/home/username/.kube/config,dst=/home/mcp/.kube/config",
+        "--mount",
+        "type=bind,src=/home/username/.kube/config,dst=/home/mcp/.kube/config",
         "ghcr.io/azure/mcp-kubernetes"
       ]
     }
@@ -74,10 +75,7 @@ Config your MCP servers in [Claude Desktop](https://claude.ai/download), [Cursor
   "mcpServers": {
     "kubernetes": {
       "command": "<path of binary 'mcp-kubernetes'>",
-      "args": [
-        "--transport",
-        "stdio"
-      ],
+      "args": ["--transport", "stdio"],
       "env": {
         "KUBECONFIG": "<your-kubeconfig-path>"
       }
@@ -107,20 +105,44 @@ Usage of ./mcp-kubernetes:
 
 ### Access Levels
 
-The `--access-level` flag controls what operations are allowed:
+The `--access-level` flag controls what operations are allowed and which tools are available:
 
 - **`readonly`** (default): Only read operations are allowed (get, describe, logs, etc.)
+  - Available tools: 4 kubectl tools for viewing resources
 - **`readwrite`**: Read and write operations are allowed (create, delete, apply, etc.)
+  - Available tools: 6 kubectl tools for managing resources
 - **`admin`**: All operations are allowed, including admin operations (cordon, drain, taint, etc.)
+  - Available tools: All 7 kubectl tools including node management
+
+Tools are filtered at registration time based on the access level, so AI assistants only see tools they can actually use.
 
 Example configurations:
 
 ```json
+// Read-only access (default)
+{
+  "mcpServers": {
+    "kubernetes": {
+      "command": "mcp-kubernetes"
+    }
+  }
+}
+
+// Read-write access
+{
+  "mcpServers": {
+    "kubernetes": {
+      "command": "mcp-kubernetes",
+      "args": ["--access-level", "readwrite"]
+    }
+  }
+}
+
 // Admin access
 {
   "mcpServers": {
     "kubernetes": {
-      "command": "mcp-kubernetes", 
+      "command": "mcp-kubernetes",
       "args": ["--access-level", "admin"]
     }
   }
@@ -129,87 +151,270 @@ Example configurations:
 
 ## Usage
 
-Ask any questions about Kubernetes cluster in your AI client, e.g.
+Ask any questions about Kubernetes cluster in your AI client. The MCP tools make it easier for AI assistants to understand and use kubectl operations.
+
+### Example Queries
 
 ```txt
 What is the status of my Kubernetes cluster?
 
 What is wrong with my nginx pod?
+
+Show me all deployments in the production namespace
+
+Scale my web deployment to 5 replicas
+
+Check if I have permission to create pods
 ```
 
 ## Available Tools
 
-The mcp-kubernetes server provides the following tools for interacting with Kubernetes clusters:
+The mcp-kubernetes server provides consolidated kubectl tools that group related operations together. Tools are automatically filtered based on your access level.
+
+### Kubectl Tools
 
 <details>
+<summary><b>kubectl_resources</b> - Manage Kubernetes resources</summary>
 
-<summary> Read-Only Tools </summary>
+**Available in**: readonly, readwrite, admin
 
-#### Read-Only Tools
+Handles CRUD operations on Kubernetes resources. In readonly mode, only supports `get` and `describe` operations.
 
-- `kubectl_get`: Get Kubernetes resources
-- `kubectl_describe`: Show detailed information about Kubernetes resources
-- `kubectl_explain`: Get documentation for Kubernetes resources
-- `kubectl_logs`: Print logs from containers in pods
-- `kubectl_api_resources`: List available API resources
-- `kubectl_api_versions`: List available API versions
-- `kubectl_diff`: Show differences between current state and applied changes
-- `kubectl_cluster_info`: Display cluster information
-- `kubectl_top`: Display resource usage (CPU/Memory)
-- `kubectl_events`: List events in the cluster
-- `kubectl_auth`: Inspect authorization settings
+**Parameters:**
+
+- `operation`: The operation to perform (get, describe, create, delete, apply, patch, replace)
+- `resource`: The resource type (e.g., pods, deployments, services) or empty for file-based operations
+- `args`: Additional arguments like resource names, namespaces, and flags
+
+**Examples:**
+
+```bash
+# Get all pods
+operation: "get"
+resource: "pods"
+args: "--all-namespaces"
+
+# Apply a configuration
+operation: "apply"
+resource: ""
+args: "-f deployment.yaml"
+```
 
 </details>
 
 <details>
+<summary><b>kubectl_workloads</b> - Manage workload deployments</summary>
 
-<summary> Read-Write Tools </summary>
+**Available in**: readwrite, admin
 
-#### Read-Write Tools
+Manages deployment lifecycle operations including scaling and rollouts.
 
-- `kubectl_create`: Create Kubernetes resources
-- `kubectl_delete`: Delete Kubernetes resources
-- `kubectl_apply`: Apply configurations to resources
-- `kubectl_expose`: Expose a resource as a new Kubernetes service
-- `kubectl_run`: Run a particular image in the cluster
-- `kubectl_set`: Set specific features on objects
-- `kubectl_rollout`: Manage rollouts of deployments
-- `kubectl_scale`: Scale deployments, statefulsets, and replicasets
-- `kubectl_autoscale`: Auto-scale deployments, statefulsets, and replicasets
-- `kubectl_label`: Update labels on resources
-- `kubectl_annotate`: Update annotations on resources
-- `kubectl_patch`: Update fields of resources using strategic merge patch
-- `kubectl_replace`: Replace existing resources
-- `kubectl_cp`: Copy files between containers and local filesystems
-- `kubectl_exec`: Execute commands in containers
+**Parameters:**
 
-</details>
+- `operation`: The operation to perform (run, expose, scale, autoscale, rollout)
+- `resource`: For rollout operations, the subcommand (status, history, undo, restart, pause, resume)
+- `args`: Additional arguments
 
-<details>
+**Examples:**
 
-<summary> Admin Tools </summary>
+```bash
+# Scale a deployment
+operation: "scale"
+resource: "deployment"
+args: "nginx --replicas=3"
 
-#### Admin Tools
-
-- `kubectl_cordon`: Mark node as unschedulable
-- `kubectl_uncordon`: Mark node as schedulable
-- `kubectl_drain`: Drain node for maintenance
-- `kubectl_taint`: Update taints on nodes
-- `kubectl_certificate`: Modify certificate resources
+# Check rollout status
+operation: "rollout"
+resource: "status"
+args: "deployment/nginx"
+```
 
 </details>
 
 <details>
-<summary> Helm Tools </summary>
+<summary><b>kubectl_metadata</b> - Manage resource metadata</summary>
 
-#### Helm Tools
+**Available in**: readwrite, admin
 
-- **Run-helm-command**: Run helm commands and get results
+Updates labels, annotations, and other metadata on resources.
+
+**Parameters:**
+
+- `operation`: The operation to perform (label, annotate, set)
+- `resource`: The resource type
+- `args`: Resource name and metadata changes
+
+**Examples:**
+
+```bash
+# Add a label
+operation: "label"
+resource: "pods"
+args: "nginx-pod app=web"
+
+# Set image
+operation: "set"
+resource: "image"
+args: "deployment/nginx nginx=nginx:latest"
+```
 
 </details>
 
-> Note: Read-write and admin tools are only available when the server is not run in read-only mode.
+<details>
+<summary><b>kubectl_diagnostics</b> - Debug and monitor resources</summary>
 
+**Available in**: readonly, readwrite, admin
+
+Provides debugging and monitoring capabilities.
+
+**Parameters:**
+
+- `operation`: The operation to perform (logs, events, top, exec, cp)
+- `resource`: The resource type or specific resource
+- `args`: Additional arguments
+
+**Examples:**
+
+```bash
+# View logs
+operation: "logs"
+resource: ""
+args: "nginx-pod -f"
+
+# Execute command in pod
+operation: "exec"
+resource: ""
+args: "nginx-pod -- ls /app"
+```
+
+</details>
+
+<details>
+<summary><b>kubectl_cluster</b> - View cluster information</summary>
+
+**Available in**: readonly, readwrite, admin
+
+Provides cluster-level information and API discovery.
+
+**Parameters:**
+
+- `operation`: The operation to perform (cluster-info, api-resources, api-versions, explain)
+- `resource`: For explain operation, the resource to document
+- `args`: Additional flags
+
+**Examples:**
+
+```bash
+# Get cluster info
+operation: "cluster-info"
+resource: ""
+args: ""
+
+# Explain pod spec
+operation: "explain"
+resource: "pod.spec"
+args: "--recursive"
+```
+
+</details>
+
+<details>
+<summary><b>kubectl_nodes</b> - Manage cluster nodes</summary>
+
+**Available in**: admin only
+
+Manages node-level operations for cluster maintenance.
+
+**Parameters:**
+
+- `operation`: The operation to perform (cordon, uncordon, drain, taint)
+- `resource`: Usually 'node' or 'nodes'
+- `args`: Node names and operation-specific flags
+
+**Examples:**
+
+```bash
+# Drain a node
+operation: "drain"
+resource: "node"
+args: "worker-1 --ignore-daemonsets"
+
+# Add a taint
+operation: "taint"
+resource: "nodes"
+args: "worker-1 key=value:NoSchedule"
+```
+
+</details>
+
+<details>
+<summary><b>kubectl_config</b> - Configuration and security</summary>
+
+**Available in**: readonly, readwrite, admin
+
+Handles configuration validation and security operations. In readonly mode, only supports `diff` and `auth can-i`.
+
+**Parameters:**
+
+- `operation`: The operation to perform (diff, auth, certificate)
+- `resource`: Subcommand for auth/certificate operations
+- `args`: Operation-specific arguments
+
+**Examples:**
+
+```bash
+# Check permissions
+operation: "auth"
+resource: "can-i"
+args: "create pods"
+
+# Approve certificate
+operation: "certificate"
+resource: "approve"
+args: "csr-name"
+```
+
+</details>
+
+### Additional Tools
+
+<details>
+<summary><b>helm</b> - Helm package manager</summary>
+
+**Available when**: `--additional-tools=helm` is specified
+
+Run Helm commands for managing Kubernetes applications.
+
+**Parameters:**
+
+- `command`: The helm command to execute
+
+**Example:**
+
+```bash
+command: "list --all-namespaces"
+```
+
+</details>
+
+<details>
+<summary><b>cilium</b> - Cilium CNI commands</summary>
+
+**Available when**: `--additional-tools=cilium` is specified
+
+Run Cilium commands for network policies and observability.
+
+**Parameters:**
+
+- `command`: The cilium command to execute
+
+**Example:**
+
+```bash
+command: "status --brief"
+```
+
+</details>
 
 ## Development
 
@@ -221,22 +426,12 @@ npx @modelcontextprotocol/inspector <path of binary 'mcp-kubernetes'>
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
 
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+When you submit a pull request, a CLA bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/pkg/cilium/registry.go
+++ b/pkg/cilium/registry.go
@@ -6,11 +6,11 @@ import (
 
 // RegisterCilium registers the cilium tool
 func RegisterCilium() mcp.Tool {
-	return mcp.NewTool("Run-cilium-command",
-		mcp.WithDescription("Run cilium command and get result, The command should start with cilium"),
+	return mcp.NewTool("cilium",
+		mcp.WithDescription("Run Cilium CNI commands for network policies and observability"),
 		mcp.WithString("command",
 			mcp.Required(),
-			mcp.Description("The cilium command to execute"),
+			mcp.Description("The cilium command to execute (e.g., 'cilium status', 'cilium endpoint list')"),
 		),
 	)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,8 +98,3 @@ func IsToolSupported(tool string) bool {
 	}
 	return false
 }
-
-// AvailableTools returns the list of available tools
-func AvailableTools() []string {
-	return availableTools
-}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ func TestAccessLevelValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := NewConfig()
 			cfg.AccessLevel = tt.accessLevel
-			
+
 			// Skip flag parsing, just test the validation logic
 			var err error
 			switch cfg.AccessLevel {

--- a/pkg/helm/registry.go
+++ b/pkg/helm/registry.go
@@ -6,11 +6,11 @@ import (
 
 // RegisterHelm registers the helm tool
 func RegisterHelm() mcp.Tool {
-	return mcp.NewTool("Run-helm-command",
-		mcp.WithDescription("Run helm command and get result, The command should start with helm"),
+	return mcp.NewTool("helm",
+		mcp.WithDescription("Run Helm package manager commands for Kubernetes"),
 		mcp.WithString("command",
 			mcp.Required(),
-			mcp.Description("The helm command to execute"),
+			mcp.Description("The helm command to execute (e.g., 'helm list', 'helm install myapp ./chart')"),
 		),
 	)
 }

--- a/pkg/kubectl/executor.go
+++ b/pkg/kubectl/executor.go
@@ -81,12 +81,3 @@ func (e *KubectlExecutor) ExecuteSpecificCommand(cmd string, params map[string]i
 	// Execute the command
 	return e.executeKubectlCommand(cmd, args, cfg)
 }
-
-// CreateCommandExecutorFunc creates a CommandExecutor for a specific kubectl command
-func CreateCommandExecutorFunc(cmd string) tools.CommandExecutorFunc {
-	f := func(params map[string]interface{}, cfg *config.ConfigData) (string, error) {
-		executor := NewExecutor()
-		return executor.ExecuteSpecificCommand(cmd, params, cfg)
-	}
-	return tools.CommandExecutorFunc(f)
-}

--- a/pkg/kubectl/kubectl_executor.go
+++ b/pkg/kubectl/kubectl_executor.go
@@ -1,0 +1,312 @@
+package kubectl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/mcp-kubernetes/pkg/config"
+	"github.com/Azure/mcp-kubernetes/pkg/security"
+)
+
+// KubectlToolExecutor handles structured kubectl command execution for grouped tools
+type KubectlToolExecutor struct {
+	executor *KubectlExecutor
+}
+
+// NewKubectlToolExecutor creates a new kubectl tool executor
+func NewKubectlToolExecutor() *KubectlToolExecutor {
+	return &KubectlToolExecutor{
+		executor: NewExecutor(),
+	}
+}
+
+// Execute processes structured kubectl commands with operation/resource/args parameters
+func (e *KubectlToolExecutor) Execute(params map[string]interface{}, cfg *config.ConfigData) (string, error) {
+	// Extract structured parameters
+	operation, ok := params["operation"].(string)
+	if !ok {
+		return "", fmt.Errorf("operation parameter is required and must be a string")
+	}
+
+	resource, ok := params["resource"].(string)
+	if !ok {
+		return "", fmt.Errorf("resource parameter is required and must be a string")
+	}
+
+	args, ok := params["args"].(string)
+	if !ok {
+		return "", fmt.Errorf("args parameter is required and must be a string")
+	}
+
+	// Get the tool name from params (injected by handler)
+	toolName, _ := params["_tool_name"].(string)
+
+	// Validate the operation/resource combination
+	if err := e.validateCombination(toolName, operation, resource); err != nil {
+		return "", err
+	}
+
+	// Map operation to kubectl command
+	kubectlCommand, err := MapOperationToCommand(toolName, operation, resource)
+	if err != nil {
+		return "", err
+	}
+
+	// Build the full command
+	fullCommand := e.buildCommand(kubectlCommand, resource, args)
+
+	// Check access level for the command
+	if err := e.checkAccessLevel(fullCommand, cfg); err != nil {
+		return "", err
+	}
+
+	// Validate the command against security settings
+	validator := security.NewValidator(cfg.SecurityConfig)
+	if err := validator.ValidateCommand(fullCommand, security.CommandTypeKubectl); err != nil {
+		return "", err
+	}
+
+	// Execute the command directly
+	return e.executor.executeKubectlCommand(fullCommand, "", cfg)
+}
+
+// validateCombination validates if the operation/resource combination is valid for the tool
+func (e *KubectlToolExecutor) validateCombination(toolName, operation, resource string) error {
+	switch toolName {
+	case "kubectl_resources":
+		return e.validateResourcesOperation(operation)
+	case "kubectl_workloads":
+		return e.validateWorkloadsOperation(operation, resource)
+	case "kubectl_metadata":
+		return e.validateMetadataOperation(operation)
+	case "kubectl_diagnostics":
+		return e.validateDiagnosticsOperation(operation)
+	case "kubectl_cluster":
+		return e.validateClusterOperation(operation)
+	case "kubectl_nodes":
+		return e.validateNodesOperation(operation)
+	case "kubectl_config":
+		return e.validateConfigOperation(operation, resource)
+	default:
+		return fmt.Errorf("unknown tool: %s", toolName)
+	}
+}
+
+// validateResourcesOperation validates operations for the resources tool
+func (e *KubectlToolExecutor) validateResourcesOperation(operation string) error {
+	// Always allow read-only operations
+	readOnlyOps := []string{"get", "describe"}
+	for _, validOp := range readOnlyOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+
+	// For write operations, they will be validated by the access level check
+	writeOps := []string{"create", "delete", "apply", "patch", "replace"}
+	for _, validOp := range writeOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+
+	allOps := append(readOnlyOps, writeOps...)
+	return fmt.Errorf("invalid operation '%s' for resources tool. Valid operations: %s",
+		operation, strings.Join(allOps, ", "))
+}
+
+// validateWorkloadsOperation validates operations for the workloads tool
+func (e *KubectlToolExecutor) validateWorkloadsOperation(operation, resource string) error {
+	validOps := []string{"run", "expose", "scale", "autoscale", "rollout"}
+	for _, validOp := range validOps {
+		if operation == validOp {
+			// Special validation for rollout subcommands
+			if operation == "rollout" {
+				validSubcmds := []string{"status", "history", "undo", "restart", "pause", "resume"}
+				for _, subcmd := range validSubcmds {
+					if resource == subcmd {
+						return nil
+					}
+				}
+				return fmt.Errorf("invalid rollout subcommand '%s'. Valid subcommands: %s",
+					resource, strings.Join(validSubcmds, ", "))
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid operation '%s' for workloads tool. Valid operations: %s",
+		operation, strings.Join(validOps, ", "))
+}
+
+// validateMetadataOperation validates operations for the metadata tool
+func (e *KubectlToolExecutor) validateMetadataOperation(operation string) error {
+	validOps := []string{"label", "annotate", "set"}
+	for _, validOp := range validOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid operation '%s' for metadata tool. Valid operations: %s",
+		operation, strings.Join(validOps, ", "))
+}
+
+// validateDiagnosticsOperation validates operations for the diagnostics tool
+func (e *KubectlToolExecutor) validateDiagnosticsOperation(operation string) error {
+	validOps := []string{"logs", "events", "top", "exec", "cp"}
+	for _, validOp := range validOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid operation '%s' for diagnostics tool. Valid operations: %s",
+		operation, strings.Join(validOps, ", "))
+}
+
+// validateClusterOperation validates operations for the cluster tool
+func (e *KubectlToolExecutor) validateClusterOperation(operation string) error {
+	validOps := []string{"cluster-info", "api-resources", "api-versions", "explain"}
+	for _, validOp := range validOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid operation '%s' for cluster tool. Valid operations: %s",
+		operation, strings.Join(validOps, ", "))
+}
+
+// validateNodesOperation validates operations for the nodes tool
+func (e *KubectlToolExecutor) validateNodesOperation(operation string) error {
+	validOps := []string{"cordon", "uncordon", "drain", "taint"}
+	for _, validOp := range validOps {
+		if operation == validOp {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid operation '%s' for nodes tool. Valid operations: %s",
+		operation, strings.Join(validOps, ", "))
+}
+
+// validateConfigOperation validates operations for the config tool
+func (e *KubectlToolExecutor) validateConfigOperation(operation, resource string) error {
+	// Always allow read-only operations
+	switch operation {
+	case "diff":
+		return nil
+	case "auth":
+		if resource != "can-i" {
+			return fmt.Errorf("auth operation requires 'can-i' as resource")
+		}
+		return nil
+	case "certificate":
+		// Certificate operations are write operations, validated by access level check
+		validSubcmds := []string{"approve", "deny"}
+		for _, subcmd := range validSubcmds {
+			if resource == subcmd {
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid certificate subcommand '%s'. Valid subcommands: %s",
+			resource, strings.Join(validSubcmds, ", "))
+	default:
+		return fmt.Errorf("invalid operation '%s' for config tool. Valid operations: diff, auth, certificate",
+			operation)
+	}
+}
+
+// buildCommand constructs the full kubectl command
+func (e *KubectlToolExecutor) buildCommand(kubectlCommand, resource, args string) string {
+	// Handle special cases where resource is part of the command
+	if strings.Contains(kubectlCommand, " ") {
+		// Command already includes subcommand (e.g., "rollout status", "auth can-i")
+		if args != "" {
+			return fmt.Sprintf("%s %s", kubectlCommand, args)
+		}
+		return kubectlCommand
+	}
+
+	// Standard case: command + resource + args
+	parts := []string{kubectlCommand}
+
+	// Add resource if not empty
+	if resource != "" {
+		parts = append(parts, resource)
+	}
+
+	// Add args if not empty
+	if args != "" {
+		parts = append(parts, args)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// checkAccessLevel validates the command against the configured access level
+func (e *KubectlToolExecutor) checkAccessLevel(command string, cfg *config.ConfigData) error {
+	// Parse the command to determine its category
+	category := e.determineCommandCategory(command)
+
+	switch cfg.AccessLevel {
+	case "readonly":
+		if category != "read-only" {
+			return fmt.Errorf("command requires %s access, but current access level is read-only", category)
+		}
+	case "readwrite":
+		if category == "admin" {
+			return fmt.Errorf("command requires admin access, but current access level is read-write")
+		}
+	case "admin":
+		// Admin can execute all commands
+	default:
+		return fmt.Errorf("unknown access level: %s", cfg.AccessLevel)
+	}
+
+	return nil
+}
+
+// determineCommandCategory determines if a command is read-only, read-write, or admin
+func (e *KubectlToolExecutor) determineCommandCategory(command string) string {
+	// Extract the base command
+	parts := strings.Fields(command)
+	if len(parts) == 0 {
+		return "read-only"
+	}
+
+	baseCmd := parts[0]
+
+	// Check if it's a read-only command
+	readOnlyCommands := GetReadOnlyKubectlCommands()
+	for _, cmd := range readOnlyCommands {
+		if cmd.Name == baseCmd {
+			return "read-only"
+		}
+	}
+
+	// Check if it's an admin command
+	adminCommands := GetAdminKubectlCommands()
+	for _, cmd := range adminCommands {
+		if cmd.Name == baseCmd {
+			return "admin"
+		}
+	}
+
+	// Special handling for complex commands
+	if baseCmd == "rollout" && len(parts) > 1 {
+		// rollout status/history are read-only
+		if parts[1] == "status" || parts[1] == "history" {
+			return "read-only"
+		}
+	}
+
+	if baseCmd == "auth" && len(parts) > 1 && parts[1] == "can-i" {
+		return "read-only"
+	}
+
+	// Default to read-write for other commands
+	return "read-write"
+}
+
+// GetCommandForValidation returns the constructed command for security validation
+func (e *KubectlToolExecutor) GetCommandForValidation(operation, resource, args string, toolName string) string {
+	kubectlCommand, _ := MapOperationToCommand(toolName, operation, resource)
+	return e.buildCommand(kubectlCommand, resource, args)
+}

--- a/pkg/kubectl/kubectl_executor_test.go
+++ b/pkg/kubectl/kubectl_executor_test.go
@@ -1,0 +1,506 @@
+package kubectl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Azure/mcp-kubernetes/pkg/config"
+	"github.com/Azure/mcp-kubernetes/pkg/security"
+)
+
+func TestKubectlToolExecutor_ValidateCombination(t *testing.T) {
+	executor := NewKubectlToolExecutor()
+
+	tests := []struct {
+		name      string
+		toolName  string
+		operation string
+		resource  string
+		wantErr   bool
+		errMsg    string
+	}{
+		// Resources tool tests
+		{
+			name:      "valid resources get",
+			toolName:  "kubectl_resources",
+			operation: "get",
+			resource:  "pods",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid resources operation",
+			toolName:  "kubectl_resources",
+			operation: "rollout",
+			resource:  "pods",
+			wantErr:   true,
+			errMsg:    "invalid operation 'rollout' for resources tool",
+		},
+		// Workloads tool tests
+		{
+			name:      "valid workloads scale",
+			toolName:  "kubectl_workloads",
+			operation: "scale",
+			resource:  "deployment",
+			wantErr:   false,
+		},
+		{
+			name:      "valid rollout status",
+			toolName:  "kubectl_workloads",
+			operation: "rollout",
+			resource:  "status",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid rollout subcommand",
+			toolName:  "kubectl_workloads",
+			operation: "rollout",
+			resource:  "invalid",
+			wantErr:   true,
+			errMsg:    "invalid rollout subcommand 'invalid'",
+		},
+		// Metadata tool tests
+		{
+			name:      "valid metadata label",
+			toolName:  "kubectl_metadata",
+			operation: "label",
+			resource:  "pods",
+			wantErr:   false,
+		},
+		// Diagnostics tool tests
+		{
+			name:      "valid diagnostics logs",
+			toolName:  "kubectl_diagnostics",
+			operation: "logs",
+			resource:  "pod",
+			wantErr:   false,
+		},
+		// Cluster tool tests
+		{
+			name:      "valid cluster info",
+			toolName:  "kubectl_cluster",
+			operation: "cluster-info",
+			resource:  "",
+			wantErr:   false,
+		},
+		// Nodes tool tests
+		{
+			name:      "valid nodes cordon",
+			toolName:  "kubectl_nodes",
+			operation: "cordon",
+			resource:  "node",
+			wantErr:   false,
+		},
+		// Config tool tests
+		{
+			name:      "valid config diff",
+			toolName:  "kubectl_config",
+			operation: "diff",
+			resource:  "",
+			wantErr:   false,
+		},
+		{
+			name:      "valid auth can-i",
+			toolName:  "kubectl_config",
+			operation: "auth",
+			resource:  "can-i",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid auth resource",
+			toolName:  "kubectl_config",
+			operation: "auth",
+			resource:  "invalid",
+			wantErr:   true,
+			errMsg:    "auth operation requires 'can-i' as resource",
+		},
+		{
+			name:      "valid certificate approve",
+			toolName:  "kubectl_config",
+			operation: "certificate",
+			resource:  "approve",
+			wantErr:   false,
+		},
+		// Unknown tool test
+		{
+			name:      "unknown tool",
+			toolName:  "kubectl_unknown",
+			operation: "get",
+			resource:  "pods",
+			wantErr:   true,
+			errMsg:    "unknown tool: kubectl_unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := executor.validateCombination(tt.toolName, tt.operation, tt.resource)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateCombination() error = nil, wantErr %v", tt.wantErr)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateCombination() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("validateCombination() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestKubectlToolExecutor_BuildCommand(t *testing.T) {
+	executor := NewKubectlToolExecutor()
+
+	tests := []struct {
+		name           string
+		kubectlCommand string
+		resource       string
+		args           string
+		want           string
+	}{
+		{
+			name:           "simple command with resource and args",
+			kubectlCommand: "get",
+			resource:       "pods",
+			args:           "-n default",
+			want:           "get pods -n default",
+		},
+		{
+			name:           "command without resource",
+			kubectlCommand: "cluster-info",
+			resource:       "",
+			args:           "--kubeconfig=/path/to/config",
+			want:           "cluster-info --kubeconfig=/path/to/config",
+		},
+		{
+			name:           "command with subcommand already included",
+			kubectlCommand: "rollout status",
+			resource:       "deployment/myapp",
+			args:           "-n production",
+			want:           "rollout status -n production",
+		},
+		{
+			name:           "command with empty args",
+			kubectlCommand: "get",
+			resource:       "nodes",
+			args:           "",
+			want:           "get nodes",
+		},
+		{
+			name:           "auth can-i command",
+			kubectlCommand: "auth can-i",
+			resource:       "",
+			args:           "create pods --namespace=default",
+			want:           "auth can-i create pods --namespace=default",
+		},
+		{
+			name:           "apply with file flag",
+			kubectlCommand: "apply",
+			resource:       "",
+			args:           "-f deployment.yaml",
+			want:           "apply -f deployment.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := executor.buildCommand(tt.kubectlCommand, tt.resource, tt.args)
+			if got != tt.want {
+				t.Errorf("buildCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKubectlToolExecutor_DetermineCommandCategory(t *testing.T) {
+	executor := NewKubectlToolExecutor()
+
+	tests := []struct {
+		name         string
+		command      string
+		wantCategory string
+	}{
+		{
+			name:         "get is read-only",
+			command:      "get pods -n default",
+			wantCategory: "read-only",
+		},
+		{
+			name:         "describe is read-only",
+			command:      "describe deployment myapp",
+			wantCategory: "read-only",
+		},
+		{
+			name:         "create is read-write",
+			command:      "create deployment nginx --image=nginx",
+			wantCategory: "read-write",
+		},
+		{
+			name:         "delete is read-write",
+			command:      "delete pod mypod",
+			wantCategory: "read-write",
+		},
+		{
+			name:         "drain is admin",
+			command:      "drain node-1 --ignore-daemonsets",
+			wantCategory: "admin",
+		},
+		{
+			name:         "rollout status is read-only",
+			command:      "rollout status deployment/myapp",
+			wantCategory: "read-only",
+		},
+		{
+			name:         "rollout restart is read-write",
+			command:      "rollout restart deployment/myapp",
+			wantCategory: "read-write",
+		},
+		{
+			name:         "auth can-i is read-only",
+			command:      "auth can-i create pods",
+			wantCategory: "read-only",
+		},
+		{
+			name:         "certificate approve is admin",
+			command:      "certificate approve csr-name",
+			wantCategory: "admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := executor.determineCommandCategory(tt.command)
+			if got != tt.wantCategory {
+				t.Errorf("determineCommandCategory() = %v, want %v", got, tt.wantCategory)
+			}
+		})
+	}
+}
+
+func TestKubectlToolExecutor_CheckAccessLevel(t *testing.T) {
+	executor := NewKubectlToolExecutor()
+
+	tests := []struct {
+		name        string
+		command     string
+		accessLevel string
+		wantErr     bool
+		errMsg      string
+	}{
+		// Read-only access tests
+		{
+			name:        "readonly can execute get",
+			command:     "get pods",
+			accessLevel: "readonly",
+			wantErr:     false,
+		},
+		{
+			name:        "readonly cannot execute create",
+			command:     "create deployment nginx --image=nginx",
+			accessLevel: "readonly",
+			wantErr:     true,
+			errMsg:      "requires read-write access",
+		},
+		{
+			name:        "readonly cannot execute drain",
+			command:     "drain node-1",
+			accessLevel: "readonly",
+			wantErr:     true,
+			errMsg:      "requires admin access",
+		},
+		// Read-write access tests
+		{
+			name:        "readwrite can execute get",
+			command:     "get pods",
+			accessLevel: "readwrite",
+			wantErr:     false,
+		},
+		{
+			name:        "readwrite can execute create",
+			command:     "create deployment nginx --image=nginx",
+			accessLevel: "readwrite",
+			wantErr:     false,
+		},
+		{
+			name:        "readwrite cannot execute drain",
+			command:     "drain node-1",
+			accessLevel: "readwrite",
+			wantErr:     true,
+			errMsg:      "requires admin access",
+		},
+		// Admin access tests
+		{
+			name:        "admin can execute get",
+			command:     "get pods",
+			accessLevel: "admin",
+			wantErr:     false,
+		},
+		{
+			name:        "admin can execute create",
+			command:     "create deployment nginx --image=nginx",
+			accessLevel: "admin",
+			wantErr:     false,
+		},
+		{
+			name:        "admin can execute drain",
+			command:     "drain node-1",
+			accessLevel: "admin",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.ConfigData{
+				AccessLevel: tt.accessLevel,
+			}
+
+			err := executor.checkAccessLevel(tt.command, cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("checkAccessLevel() error = nil, wantErr %v", tt.wantErr)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("checkAccessLevel() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("checkAccessLevel() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestKubectlToolExecutor_Execute(t *testing.T) {
+	// Note: This test validates parameter extraction and command construction
+	// but doesn't execute actual kubectl commands
+
+	tests := []struct {
+		name    string
+		params  map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid parameters",
+			params: map[string]interface{}{
+				"_tool_name": "kubectl_resources",
+				"operation":  "get",
+				"resource":   "pods",
+				"args":       "-n default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing operation",
+			params: map[string]interface{}{
+				"_tool_name": "kubectl_resources",
+				"resource":   "pods",
+				"args":       "-n default",
+			},
+			wantErr: true,
+			errMsg:  "operation parameter is required",
+		},
+		{
+			name: "missing resource",
+			params: map[string]interface{}{
+				"_tool_name": "kubectl_resources",
+				"operation":  "get",
+				"args":       "-n default",
+			},
+			wantErr: true,
+			errMsg:  "resource parameter is required",
+		},
+		{
+			name: "missing args",
+			params: map[string]interface{}{
+				"_tool_name": "kubectl_resources",
+				"operation":  "get",
+				"resource":   "pods",
+			},
+			wantErr: true,
+			errMsg:  "args parameter is required",
+		},
+		{
+			name: "invalid combination",
+			params: map[string]interface{}{
+				"_tool_name": "kubectl_resources",
+				"operation":  "rollout",
+				"resource":   "pods",
+				"args":       "",
+			},
+			wantErr: true,
+			errMsg:  "invalid operation 'rollout' for resources tool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewKubectlToolExecutor()
+			cfg := &config.ConfigData{
+				AccessLevel: "readwrite",
+				SecurityConfig: &security.SecurityConfig{
+					AccessLevel: security.AccessLevelReadWrite,
+				},
+			}
+
+			_, err := executor.Execute(tt.params, cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Execute() error = nil, wantErr %v", tt.wantErr)
+				} else if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("Execute() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			}
+			// Note: We don't test successful execution as it would require mocking kubectl
+		})
+	}
+}
+
+func TestMapOperationToCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		operation string
+		resource  string
+		want      string
+	}{
+		{
+			name:      "resources tool simple operation",
+			toolName:  "kubectl_resources",
+			operation: "get",
+			resource:  "pods",
+			want:      "get",
+		},
+		{
+			name:      "workloads rollout with subcommand",
+			toolName:  "kubectl_workloads",
+			operation: "rollout",
+			resource:  "status",
+			want:      "rollout status",
+		},
+		{
+			name:      "config auth with can-i",
+			toolName:  "kubectl_config",
+			operation: "auth",
+			resource:  "can-i",
+			want:      "auth can-i",
+		},
+		{
+			name:      "config certificate with approve",
+			toolName:  "kubectl_config",
+			operation: "certificate",
+			resource:  "approve",
+			want:      "certificate approve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MapOperationToCommand(tt.toolName, tt.operation, tt.resource)
+			if err != nil {
+				t.Errorf("MapOperationToCommand() unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("MapOperationToCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kubectl/registry_test.go
+++ b/pkg/kubectl/registry_test.go
@@ -1,0 +1,440 @@
+package kubectl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegisterKubectlTools(t *testing.T) {
+	// Test admin access level gets all tools
+	tools := RegisterKubectlTools("admin")
+
+	// Verify we have the expected number of tools
+	expectedCount := 7
+	if len(tools) != expectedCount {
+		t.Errorf("Expected %d consolidated tools, got %d", expectedCount, len(tools))
+	}
+
+	// Verify tool names
+	expectedNames := GetKubectlToolNames()
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolNames[tool.Name] = true
+	}
+
+	for _, expectedName := range expectedNames {
+		if !toolNames[expectedName] {
+			t.Errorf("Expected tool %s not found", expectedName)
+		}
+	}
+}
+
+func TestConsolidatedToolDescriptions(t *testing.T) {
+	// Test with admin access to get all tools
+	tools := RegisterKubectlTools("admin")
+
+	tests := []struct {
+		toolName           string
+		expectedOperations []string
+		expectedInDesc     []string
+	}{
+		{
+			toolName:           "kubectl_resources",
+			expectedOperations: []string{"get", "describe", "create", "delete", "apply", "patch", "replace"},
+			expectedInDesc:     []string{"CRUD operations", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_workloads",
+			expectedOperations: []string{"run", "expose", "scale", "autoscale", "rollout"},
+			expectedInDesc:     []string{"workloads", "lifecycle", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_metadata",
+			expectedOperations: []string{"label", "annotate", "set"},
+			expectedInDesc:     []string{"metadata", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_diagnostics",
+			expectedOperations: []string{"logs", "events", "top", "exec", "cp"},
+			expectedInDesc:     []string{"Diagnose", "debug", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_cluster",
+			expectedOperations: []string{"cluster-info", "api-resources", "api-versions", "explain"},
+			expectedInDesc:     []string{"cluster", "API", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_nodes",
+			expectedOperations: []string{"cordon", "uncordon", "drain", "taint"},
+			expectedInDesc:     []string{"nodes", "Examples:"},
+		},
+		{
+			toolName:           "kubectl_config",
+			expectedOperations: []string{"diff", "auth", "certificate"},
+			expectedInDesc:     []string{"configurations", "Examples:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.toolName, func(t *testing.T) {
+			var found bool
+			var toolDesc string
+
+			for _, tool := range tools {
+				if tool.Name == tt.toolName {
+					found = true
+					toolDesc = tool.Description
+					break
+				}
+			}
+
+			if !found {
+				t.Errorf("Tool %s not found", tt.toolName)
+				return
+			}
+
+			// Check that all expected operations are mentioned
+			for _, op := range tt.expectedOperations {
+				if !strings.Contains(toolDesc, op) {
+					t.Errorf("Tool %s description missing operation: %s", tt.toolName, op)
+				}
+			}
+
+			// Check for expected content in description
+			for _, expected := range tt.expectedInDesc {
+				if !strings.Contains(toolDesc, expected) {
+					t.Errorf("Tool %s description missing expected content: %s", tt.toolName, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestConsolidatedToolParameters(t *testing.T) {
+	// Test with admin access to get all tools
+	tools := RegisterKubectlTools("admin")
+
+	// All tools should have the same three parameters
+	// expectedParams := []string{"operation", "resource", "args"}
+
+	for _, tool := range tools {
+		t.Run(tool.Name, func(t *testing.T) {
+			// We can't directly access tool parameters in the test,
+			// but we can verify the tool was created successfully
+			if tool.Name == "" {
+				t.Error("Tool has empty name")
+			}
+			if tool.Description == "" {
+				t.Error("Tool has empty description")
+			}
+		})
+	}
+}
+
+func TestGetKubectlToolNames(t *testing.T) {
+	names := GetKubectlToolNames()
+
+	expected := []string{
+		"kubectl_resources",
+		"kubectl_workloads",
+		"kubectl_metadata",
+		"kubectl_diagnostics",
+		"kubectl_cluster",
+		"kubectl_nodes",
+		"kubectl_config",
+	}
+
+	if len(names) != len(expected) {
+		t.Errorf("Expected %d tool names, got %d", len(expected), len(names))
+	}
+
+	for i, name := range expected {
+		if names[i] != name {
+			t.Errorf("Expected tool name %s at index %d, got %s", name, i, names[i])
+		}
+	}
+}
+
+func TestMapOperationToCommand_AllTools(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		operation string
+		resource  string
+		want      string
+		wantErr   bool
+	}{
+		// kubectl_resources tests
+		{
+			name:      "resources get",
+			toolName:  "kubectl_resources",
+			operation: "get",
+			resource:  "pods",
+			want:      "get",
+		},
+		{
+			name:      "resources apply",
+			toolName:  "kubectl_resources",
+			operation: "apply",
+			resource:  "",
+			want:      "apply",
+		},
+		// kubectl_workloads tests
+		{
+			name:      "workloads scale",
+			toolName:  "kubectl_workloads",
+			operation: "scale",
+			resource:  "deployment",
+			want:      "scale",
+		},
+		{
+			name:      "workloads rollout status",
+			toolName:  "kubectl_workloads",
+			operation: "rollout",
+			resource:  "status",
+			want:      "rollout status",
+		},
+		{
+			name:      "workloads rollout undo",
+			toolName:  "kubectl_workloads",
+			operation: "rollout",
+			resource:  "undo",
+			want:      "rollout undo",
+		},
+		// kubectl_metadata tests
+		{
+			name:      "metadata label",
+			toolName:  "kubectl_metadata",
+			operation: "label",
+			resource:  "pods",
+			want:      "label",
+		},
+		{
+			name:      "metadata set",
+			toolName:  "kubectl_metadata",
+			operation: "set",
+			resource:  "image",
+			want:      "set",
+		},
+		// kubectl_diagnostics tests
+		{
+			name:      "diagnostics logs",
+			toolName:  "kubectl_diagnostics",
+			operation: "logs",
+			resource:  "pod",
+			want:      "logs",
+		},
+		{
+			name:      "diagnostics exec",
+			toolName:  "kubectl_diagnostics",
+			operation: "exec",
+			resource:  "pod",
+			want:      "exec",
+		},
+		// kubectl_cluster tests
+		{
+			name:      "cluster info",
+			toolName:  "kubectl_cluster",
+			operation: "cluster-info",
+			resource:  "",
+			want:      "cluster-info",
+		},
+		{
+			name:      "cluster explain",
+			toolName:  "kubectl_cluster",
+			operation: "explain",
+			resource:  "pod",
+			want:      "explain",
+		},
+		// kubectl_nodes tests
+		{
+			name:      "nodes cordon",
+			toolName:  "kubectl_nodes",
+			operation: "cordon",
+			resource:  "node",
+			want:      "cordon",
+		},
+		{
+			name:      "nodes taint",
+			toolName:  "kubectl_nodes",
+			operation: "taint",
+			resource:  "nodes",
+			want:      "taint",
+		},
+		// kubectl_config tests
+		{
+			name:      "config diff",
+			toolName:  "kubectl_config",
+			operation: "diff",
+			resource:  "",
+			want:      "diff",
+		},
+		{
+			name:      "config auth can-i",
+			toolName:  "kubectl_config",
+			operation: "auth",
+			resource:  "can-i",
+			want:      "auth can-i",
+		},
+		{
+			name:      "config certificate approve",
+			toolName:  "kubectl_config",
+			operation: "certificate",
+			resource:  "approve",
+			want:      "certificate approve",
+		},
+		// Unknown tool test
+		{
+			name:      "unknown tool",
+			toolName:  "kubectl_unknown",
+			operation: "get",
+			resource:  "pods",
+			want:      "",
+			wantErr:   false, // MapOperationToCommand returns empty string for unknown tools
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MapOperationToCommand(tt.toolName, tt.operation, tt.resource)
+			if tt.wantErr && err == nil {
+				t.Errorf("MapOperationToCommand() error = nil, wantErr %v", tt.wantErr)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("MapOperationToCommand() unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("MapOperationToCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegisterKubectlTools_AccessLevelFiltering(t *testing.T) {
+	tests := []struct {
+		name            string
+		accessLevel     string
+		expectedTools   []string
+		unexpectedTools []string
+	}{
+		{
+			name:        "readonly access level",
+			accessLevel: "readonly",
+			expectedTools: []string{
+				"kubectl_resources",
+				"kubectl_diagnostics",
+				"kubectl_cluster",
+				"kubectl_config",
+			},
+			unexpectedTools: []string{
+				"kubectl_workloads",
+				"kubectl_metadata",
+				"kubectl_nodes",
+			},
+		},
+		{
+			name:        "readwrite access level",
+			accessLevel: "readwrite",
+			expectedTools: []string{
+				"kubectl_resources",
+				"kubectl_workloads",
+				"kubectl_metadata",
+				"kubectl_diagnostics",
+				"kubectl_cluster",
+				"kubectl_config",
+			},
+			unexpectedTools: []string{
+				"kubectl_nodes", // nodes tool is admin only
+			},
+		},
+		{
+			name:        "admin access level",
+			accessLevel: "admin",
+			expectedTools: []string{
+				"kubectl_resources",
+				"kubectl_workloads",
+				"kubectl_metadata",
+				"kubectl_diagnostics",
+				"kubectl_cluster",
+				"kubectl_nodes",
+				"kubectl_config",
+			},
+			unexpectedTools: []string{}, // admin has access to all tools
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tools := RegisterKubectlTools(tt.accessLevel)
+
+			// Check that expected tools are present
+			for _, expectedTool := range tt.expectedTools {
+				found := false
+				for _, tool := range tools {
+					if tool.Name == expectedTool {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected tool %s not found for access level %s", expectedTool, tt.accessLevel)
+				}
+			}
+
+			// Check that unexpected tools are not present
+			for _, unexpectedTool := range tt.unexpectedTools {
+				for _, tool := range tools {
+					if tool.Name == unexpectedTool {
+						t.Errorf("Unexpected tool %s found for access level %s", unexpectedTool, tt.accessLevel)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestRegisterKubectlTools_ReadOnlyDescriptions(t *testing.T) {
+	// Test that read-only access level has appropriate descriptions
+	tools := RegisterKubectlTools("readonly")
+
+	for _, tool := range tools {
+		switch tool.Name {
+		case "kubectl_resources":
+			// Check that description doesn't mention write operations
+			if strings.Contains(tool.Description, "create") ||
+				strings.Contains(tool.Description, "delete") ||
+				strings.Contains(tool.Description, "apply") {
+				t.Errorf("kubectl_resources in readonly mode should not mention write operations")
+			}
+			// Check that it mentions read operations
+			if !strings.Contains(tool.Description, "get") ||
+				!strings.Contains(tool.Description, "describe") {
+				t.Errorf("kubectl_resources in readonly mode should mention read operations")
+			}
+		case "kubectl_config":
+			// Check that description doesn't mention certificate operations
+			if strings.Contains(tool.Description, "certificate") {
+				t.Errorf("kubectl_config in readonly mode should not mention certificate operations")
+			}
+		}
+	}
+}
+
+func TestRegisterKubectlTools_DefaultsToReadOnly(t *testing.T) {
+	// Test that unknown access level defaults to readonly
+	tools := RegisterKubectlTools("unknown")
+	readonlyTools := RegisterKubectlTools("readonly")
+
+	if len(tools) != len(readonlyTools) {
+		t.Errorf("Unknown access level should default to readonly, got %d tools, expected %d",
+			len(tools), len(readonlyTools))
+	}
+
+	// Verify tool names match
+	for i, tool := range tools {
+		if tool.Name != readonlyTools[i].Name {
+			t.Errorf("Tool mismatch at index %d: got %s, expected %s",
+				i, tool.Name, readonlyTools[i].Name)
+		}
+	}
+}

--- a/pkg/security/security.go
+++ b/pkg/security/security.go
@@ -9,9 +9,9 @@ import (
 type AccessLevel string
 
 const (
-	AccessLevelReadOnly   AccessLevel = "readonly"
-	AccessLevelReadWrite  AccessLevel = "readwrite"
-	AccessLevelAdmin      AccessLevel = "admin"
+	AccessLevelReadOnly  AccessLevel = "readonly"
+	AccessLevelReadWrite AccessLevel = "readwrite"
+	AccessLevelAdmin     AccessLevel = "admin"
 )
 
 // SecurityConfig holds security-related configuration

--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -90,7 +90,7 @@ func (v *Validator) getReadWriteOperationsList(commandType string) []string {
 		// This can be expanded when helm write operations are defined
 		return []string{}
 	case CommandTypeCilium:
-		// For now, assume cilium write operations are same as read operations  
+		// For now, assume cilium write operations are same as read operations
 		// This can be expanded when cilium write operations are defined
 		return []string{}
 	default:
@@ -154,9 +154,9 @@ func (v *Validator) validateAccessLevel(command, commandType string) error {
 		}
 	case AccessLevelAdmin:
 		// Admin level allows all operations (read, write, and admin)
-		if !v.isOperationInList(operation, readOperations) && 
-		   !v.isOperationInList(operation, readWriteOperations) && 
-		   !v.isOperationInList(operation, adminOperations) {
+		if !v.isOperationInList(operation, readOperations) &&
+			!v.isOperationInList(operation, readWriteOperations) &&
+			!v.isOperationInList(operation, adminOperations) {
 			return &ValidationError{Message: "Error: Unknown operation"}
 		}
 	default:

--- a/pkg/tools/executor.go
+++ b/pkg/tools/executor.go
@@ -9,14 +9,3 @@ import (
 type CommandExecutor interface {
 	Execute(params map[string]interface{}, cfg *config.ConfigData) (string, error)
 }
-
-// CommandExecutorFunc is a function type that implements CommandExecutor
-// This allows regular functions to be used as CommandExecutors without having to create a struct
-type CommandExecutorFunc func(params map[string]interface{}, cfg *config.ConfigData) (string, error)
-
-var _ CommandExecutor = CommandExecutorFunc(nil)
-
-// Execute implements the CommandExecutor interface for CommandExecutorFunc
-func (f CommandExecutorFunc) Execute(params map[string]interface{}, cfg *config.ConfigData) (string, error) {
-	return f(params, cfg)
-}

--- a/pkg/tools/handler.go
+++ b/pkg/tools/handler.go
@@ -8,10 +8,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// ToolHandlerFunc is a function that processes tool requests
-// Deprecated: Use CommandExecutorFunc instead
-type ToolHandlerFunc func(params map[string]interface{}, cfg *config.ConfigData) (interface{}, error)
-
 // CreateToolHandler creates an adapter that converts CommandExecutor to the format expected by MCP server
 func CreateToolHandler(executor CommandExecutor, cfg *config.ConfigData) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -19,6 +15,26 @@ func CreateToolHandler(executor CommandExecutor, cfg *config.ConfigData) func(ct
 		if !ok {
 			return mcp.NewToolResultError("arguments must be a map[string]interface{}, got " + fmt.Sprintf("%T", req.Params.Arguments)), nil
 		}
+		result, err := executor.Execute(args, cfg)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		return mcp.NewToolResultText(result), nil
+	}
+}
+
+// CreateToolHandlerWithName creates an adapter for tools that need the tool name injected
+func CreateToolHandlerWithName(executor CommandExecutor, cfg *config.ConfigData, toolName string) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := req.Params.Arguments.(map[string]interface{})
+		if !ok {
+			return mcp.NewToolResultError("arguments must be a map[string]interface{}, got " + fmt.Sprintf("%T", req.Params.Arguments)), nil
+		}
+
+		// Inject the tool name into the arguments
+		args["_tool_name"] = toolName
+
 		result, err := executor.Execute(args, cfg)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil


### PR DESCRIPTION
  This PR consolidates the kubectl command organization to reduce the total number of MCP tools exposed to AI assistants.
  Previously, kubectl commands were spread across many individual tools, which could overwhelm the tool selection
  process. This change groups related kubectl commands into logical categories while maintaining the same functionality.

  Changes

  - Tool Consolidation: Grouped kubectl commands into 7 logical tools based on functionality (resources, workloads,
  metadata, diagnostics, cluster, nodes, config)
  - New Executor: Introduced KubectlExecutor to handle the consolidated tool execution with proper command routing
  - Registry Refactor: Restructured pkg/kubectl/registry.go to organize commands by their new tool groupings
  - Documentation Update: Updated README.md to reflect the new consolidated tool structure and provide clear usage
  examples

  Benefits

  - Reduces cognitive load for AI assistants when selecting appropriate tools
  - Maintains all existing kubectl functionality with better organization
  - Improves discoverability of related commands
  - Simplifies the MCP tool interface while preserving granular access control

  Testing

  - Added comprehensive tests for the new KubectlExecutor
  - Added registry tests to ensure proper command categorization
  - All existing security validations and access controls remain in place
