### PR TITLE
Add kubectl config operations for context management

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ Show me all deployments in the production namespace
 Scale my web deployment to 5 replicas
 
 Check if I have permission to create pods
+
+What is my current kubectl context?
+
+List all available kubectl contexts
+
+Switch to the production context
 ```
 
 ## Available Tools
@@ -335,12 +341,12 @@ args: "--recursive"
 
 **Available in**: readonly, readwrite, admin
 
-Handles configuration validation and security operations. In readonly mode, only supports `diff` and `auth can-i`.
+Handles configuration validation, security operations, and kubectl context management. In readonly mode, supports `diff`, `auth can-i`, and read-only config operations.
 
 **Parameters:**
 
-- `operation`: The operation to perform (diff, auth, certificate)
-- `resource`: Subcommand for auth/certificate operations
+- `operation`: The operation to perform (diff, auth, certificate, config)
+- `resource`: Subcommand for auth/certificate/config operations
 - `args`: Operation-specific arguments
 
 **Examples:**
@@ -355,7 +361,27 @@ args: "create pods"
 operation: "certificate"
 resource: "approve"
 args: "csr-name"
+
+# Get current context
+operation: "config"
+resource: "current-context"
+args: ""
+
+# List all contexts
+operation: "config"
+resource: "get-contexts"
+args: ""
+
+# Switch context (readwrite/admin only)
+operation: "config"
+resource: "use-context"
+args: "my-cluster-context"
 ```
+
+**Config Operations:**
+- `current-context`: Display the current context (readonly, readwrite, admin)
+- `get-contexts`: List all available contexts (readonly, readwrite, admin)
+- `use-context`: Switch to a different context (readwrite, admin only)
 
 </details>
 

--- a/pkg/kubectl/kubectl_executor.go
+++ b/pkg/kubectl/kubectl_executor.go
@@ -202,8 +202,20 @@ func (e *KubectlToolExecutor) validateConfigOperation(operation, resource string
 		}
 		return fmt.Errorf("invalid certificate subcommand '%s'. Valid subcommands: %s",
 			resource, strings.Join(validSubcmds, ", "))
+	case "config":
+		// Config operations for context and configuration management
+		validSubcmds := []string{
+			"current-context", "get-contexts", "use-context",
+		}
+		for _, subcmd := range validSubcmds {
+			if resource == subcmd {
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid config subcommand '%s'. Valid subcommands: %s",
+			resource, strings.Join(validSubcmds, ", "))
 	default:
-		return fmt.Errorf("invalid operation '%s' for config tool. Valid operations: diff, auth, certificate",
+		return fmt.Errorf("invalid operation '%s' for config tool. Valid operations: diff, auth, certificate, config",
 			operation)
 	}
 }

--- a/pkg/kubectl/kubectl_executor_test.go
+++ b/pkg/kubectl/kubectl_executor_test.go
@@ -127,6 +127,44 @@ func TestKubectlToolExecutor_ValidateCombination(t *testing.T) {
 			resource:  "approve",
 			wantErr:   false,
 		},
+		// Config operations tests
+		{
+			name:      "valid config current-context",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "current-context",
+			wantErr:   false,
+		},
+		{
+			name:      "valid config get-contexts",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "get-contexts",
+			wantErr:   false,
+		},
+		{
+			name:      "valid config use-context",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "use-context",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid config resource",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "invalid-resource",
+			wantErr:   true,
+			errMsg:    "invalid config subcommand 'invalid-resource'",
+		},
+		{
+			name:      "invalid config operation",
+			toolName:  "kubectl_config",
+			operation: "invalid-operation",
+			resource:  "",
+			wantErr:   true,
+			errMsg:    "invalid operation 'invalid-operation' for config tool",
+		},
 		// Unknown tool test
 		{
 			name:      "unknown tool",

--- a/pkg/kubectl/registry.go
+++ b/pkg/kubectl/registry.go
@@ -365,16 +365,18 @@ func createConfigTool(readOnly bool) mcp.Tool {
 Available operations:
 - diff: Diff the live version against what would be applied
 - auth: Inspect authorization (can-i)
+- config: View kubectl configuration contexts (read-only)
+
+Config operations (read-only):
+- current-context: Display the current context
+- get-contexts: Describe one or many contexts
 
 Examples:
 - Diff config: operation='diff', resource='', args='-f pod.json'
-- Diff from stdin: operation='diff', resource='', args='-f -'
-- Diff with selector: operation='diff', resource='', args='-f manifest.yaml -l app=nginx'
 - Check auth: operation='auth', resource='can-i', args='create pods --all-namespaces'
-- Check auth resource: operation='auth', resource='can-i', args='list deployments.apps'
-- Check auth as user: operation='auth', resource='can-i', args='list pods --as=system:serviceaccount:dev:foo -n prod'
-- List permissions: operation='auth', resource='can-i', args='--list --namespace=foo'`
-		operationDesc = "The operation to perform: diff, auth"
+- Get current context: operation='config', resource='current-context', args=''
+- List contexts: operation='config', resource='get-contexts', args=''`
+		operationDesc = "The operation to perform: diff, auth, config"
 	} else {
 		description = `Work with Kubernetes configurations.
 
@@ -382,17 +384,21 @@ Available operations:
 - diff: Diff the live version against what would be applied
 - auth: Inspect authorization (can-i)
 - certificate: Manage certificate resources (approve, deny)
+- config: View and manage kubectl configuration contexts
+
+Config operations:
+- current-context: Display the current context
+- get-contexts: Describe one or many contexts
+- use-context: Set the current context in kubeconfig
 
 Examples:
 - Diff config: operation='diff', resource='', args='-f pod.json'
-- Diff with selector: operation='diff', resource='', args='-f manifest.yaml -l app=nginx'
 - Check auth: operation='auth', resource='can-i', args='create pods --all-namespaces'
-- Check auth resource: operation='auth', resource='can-i', args='list deployments.apps'
-- Check auth as user: operation='auth', resource='can-i', args='list pods --as=system:serviceaccount:dev:foo -n prod'
-- List permissions: operation='auth', resource='can-i', args='--list --namespace=foo'
 - Approve cert: operation='certificate', resource='approve', args='csr-name'
-- Deny cert: operation='certificate', resource='deny', args='csr-name'`
-		operationDesc = "The operation to perform: diff, auth, certificate"
+- Get current context: operation='config', resource='current-context', args=''
+- List contexts: operation='config', resource='get-contexts', args=''
+- Switch context: operation='config', resource='use-context', args='my-cluster-context'`
+		operationDesc = "The operation to perform: diff, auth, certificate, config"
 	}
 
 	return mcp.NewTool("kubectl_config",
@@ -403,7 +409,7 @@ Examples:
 		),
 		mcp.WithString("resource",
 			mcp.Required(),
-			mcp.Description("Subcommand for auth/certificate operations, or empty string '' for diff operation"),
+			mcp.Description("Subcommand for auth/certificate/config operations, or empty string '' for diff operation"),
 		),
 		mcp.WithString("args",
 			mcp.Required(),
@@ -448,6 +454,9 @@ func MapOperationToCommand(toolName, operation, resource string) (string, error)
 		}
 		if operation == "certificate" {
 			return "certificate " + resource, nil
+		}
+		if operation == "config" {
+			return "config " + resource, nil
 		}
 		return operation, nil
 	default:

--- a/pkg/kubectl/registry_test.go
+++ b/pkg/kubectl/registry_test.go
@@ -65,7 +65,7 @@ func TestConsolidatedToolDescriptions(t *testing.T) {
 		},
 		{
 			toolName:           "kubectl_config",
-			expectedOperations: []string{"diff", "auth", "certificate"},
+			expectedOperations: []string{"diff", "auth", "certificate", "config"},
 			expectedInDesc:     []string{"configurations", "Examples:"},
 		},
 	}
@@ -276,6 +276,28 @@ func TestMapOperationToCommand_AllTools(t *testing.T) {
 			operation: "certificate",
 			resource:  "approve",
 			want:      "certificate approve",
+		},
+		// kubectl_config config operations tests
+		{
+			name:      "config current-context",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "current-context",
+			want:      "config current-context",
+		},
+		{
+			name:      "config get-contexts",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "get-contexts",
+			want:      "config get-contexts",
+		},
+		{
+			name:      "config use-context",
+			toolName:  "kubectl_config",
+			operation: "config",
+			resource:  "use-context",
+			want:      "config use-context",
 		},
 		// Unknown tool test
 		{

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -33,6 +33,19 @@ func TestValidatorAccessLevels(t *testing.T) {
 		{"Admin - create deployment", AccessLevelAdmin, "kubectl create deployment nginx --image=nginx", false, ""},
 		{"Admin - cordon node", AccessLevelAdmin, "kubectl cordon node1", false, ""},
 		{"Admin - drain node", AccessLevelAdmin, "kubectl drain node1", false, ""},
+
+		// Config operations tests
+		{"ReadOnly - config current-context", AccessLevelReadOnly, "config current-context", false, ""},
+		{"ReadOnly - config get-contexts", AccessLevelReadOnly, "config get-contexts", false, ""},
+		{"ReadOnly - config use-context", AccessLevelReadOnly, "config use-context mycontext", true, "config write operations in read-only mode"},
+
+		{"ReadWrite - config current-context", AccessLevelReadWrite, "config current-context", false, ""},
+		{"ReadWrite - config get-contexts", AccessLevelReadWrite, "config get-contexts", false, ""},
+		{"ReadWrite - config use-context", AccessLevelReadWrite, "config use-context mycontext", false, ""},
+
+		{"Admin - config current-context", AccessLevelAdmin, "config current-context", false, ""},
+		{"Admin - config get-contexts", AccessLevelAdmin, "config get-contexts", false, ""},
+		{"Admin - config use-context", AccessLevelAdmin, "config use-context mycontext", false, ""},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Adds support for kubectl config operations to view and manage kubectl contexts:
- current-context: Display the current context
- get-contexts: List all available contexts
- use-context: Switch to a different context (readwrite/admin only)

Updates validation logic to properly handle config operations with appropriate
access level restrictions and comprehensive test coverage.