### PR TITLE
ci: bump Go to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
           cache: true
 
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
           cache: true
 
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
           cache: true
 

--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -60,7 +60,7 @@ jobs:
     needs: args
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
-      go-version: 1.23
+      go-version: 1.25
       private-repository: true
       config-file: .slsa-goreleaser/${{matrix.os}}-${{matrix.arch}}.yml
       evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"


### PR DESCRIPTION
The otel 1.43 (#125) and mcp-go 0.54 (#103) dependency bumps raise the module's minimum Go version to 1.25. CI currently pins Go 1.24 with `GOTOOLCHAIN=local`, which blocks the toolchain auto-download, so those PRs fail at `go mod download` before any test runs.

This bumps `setup-go` to 1.25 in ci.yml (Lint/Test/Build) and the SLSA publish workflow (was on 1.23). Once merged, #125 and #103 can be rebased and will go green.