### PR TITLE
build: bump Dockerfile golang base to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 ARG VERSION
 ARG GIT_COMMIT
 ARG BUILD_DATE


### PR DESCRIPTION
Follow-up to #139. The CI workflows now use Go 1.25, but the Docker builder stage still pinned `golang:1.24-alpine`, so the **Build Linux** job fails at `go mod download` for the otel 1.43 (#125) and mcp-go 0.54 (#103) bumps:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

Bumps the base image to `golang:1.25-alpine` to match.