### PR TITLE
fix(security): enforce --allow-namespaces for commands without -n

### DIFF
--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -469,12 +469,30 @@ func kubectlOnlyTargetsClusterScopedResources(tokens []string, operation string)
 		return false
 	}
 
-	// kubectl's grammar: the first positional after the verb is the resource
-	// type (or a comma-separated list of types, or a TYPE/NAME pair).
-	// Subsequent positionals are names. We only inspect the first.
-	for _, rt := range splitResourceTypes(resourceArgs[0]) {
-		if !kubectlClusterScopedResources[strings.ToLower(rt)] {
+	// kubectl get accepts two grammars:
+	//   1. <type> <name1> <name2> ...        — type appears once, the rest are names
+	//   2. <type>/<name> <type>/<name> ...   — every positional is its own type/name pair
+	// If the first positional uses the resource/name form, we must inspect
+	// EVERY positional (each carries its own type). Otherwise the first
+	// positional carries the only type and the rest are names we can ignore.
+	firstIsSlash := strings.Contains(resourceArgs[0], "/")
+
+	argsToCheck := resourceArgs[:1]
+	if firstIsSlash {
+		argsToCheck = resourceArgs
+	}
+
+	for _, arg := range argsToCheck {
+		// In slash-form pass, ignore positionals that are not themselves
+		// slash form (they would be stray names left over from a malformed
+		// command — be conservative and reject).
+		if firstIsSlash && !strings.Contains(arg, "/") {
 			return false
+		}
+		for _, rt := range splitResourceTypes(arg) {
+			if !kubectlClusterScopedResources[strings.ToLower(rt)] {
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -81,6 +81,35 @@ var (
 	HubbleReadOperations = []string{
 		"status", "version", "help", "observe", "status", "list", "config",
 	}
+
+	// kubectlNamespaceExemptOperations are kubectl operations that are not bound to
+	// a single namespace and may therefore be executed without an explicit -n flag
+	// even when --allow-namespaces is configured. These cover cluster-info /
+	// version / kubeconfig-style introspection and help commands.
+	kubectlNamespaceExemptOperations = map[string]bool{
+		"version":       true,
+		"cluster-info":  true,
+		"api-resources": true,
+		"api-versions":  true,
+		"config":        true,
+		"completion":    true,
+		"help":          true,
+		"options":       true,
+		"plugin":        true,
+		"explain":       true,
+	}
+
+	// helmNamespaceExemptOperations mirror kubectlNamespaceExemptOperations for helm.
+	helmNamespaceExemptOperations = map[string]bool{
+		"version":    true,
+		"env":        true,
+		"repo":       true,
+		"search":     true,
+		"completion": true,
+		"help":       true,
+		"verify":     true,
+		"show":       true,
+	}
 )
 
 // Validator handles validation of commands against security configuration
@@ -177,7 +206,7 @@ func (v *Validator) ValidateCommand(command, commandType string) error {
 	}
 
 	// Check namespace scope restrictions
-	if err := v.validateNamespaceScope(command); err != nil {
+	if err := v.validateNamespaceScope(command, commandType); err != nil {
 		return err
 	}
 
@@ -258,7 +287,7 @@ func (v *Validator) validateAccessLevel(command, commandType string) error {
 }
 
 // validateNamespaceScope validates if a command's namespace scope is allowed by security settings
-func (v *Validator) validateNamespaceScope(command string) error {
+func (v *Validator) validateNamespaceScope(command, commandType string) error {
 	// Extract namespace from command
 	namespace := v.extractNamespaceFromCommand(command)
 
@@ -267,8 +296,10 @@ func (v *Validator) validateNamespaceScope(command string) error {
 		return &ValidationError{Message: "Error: Command contains multiple namespace flags which is not allowed"}
 	}
 
+	hasRestrictions := len(v.secConfig.allowedNamespaces) > 0 || len(v.secConfig.allowedNamespacesRe) > 0
+
 	// If command applies to all namespaces, and there are namespace restrictions
-	if namespace == "*" && (len(v.secConfig.allowedNamespaces) > 0 || len(v.secConfig.allowedNamespacesRe) > 0) {
+	if namespace == "*" && hasRestrictions {
 		return &ValidationError{Message: "Error: Access to all namespaces is restricted by security configuration"}
 	}
 
@@ -279,9 +310,39 @@ func (v *Validator) validateNamespaceScope(command string) error {
 				Message: "Error: Access to namespace '" + namespace + "' is denied by security configuration",
 			}
 		}
+		return nil
+	}
+
+	// No explicit namespace was found. When allowlist restrictions are active,
+	// commands without an explicit namespace would otherwise execute in the
+	// kubeconfig current namespace, which silently bypasses the allowlist.
+	// Reject these unless the operation is cluster-scoped or non-resource (e.g.
+	// kubectl version, kubectl cluster-info, kubectl config ...).
+	if namespace == "" && hasRestrictions {
+		operation := v.extractOperationFromCommand(command, commandType)
+		if v.isNamespaceExemptOperation(operation, commandType) {
+			return nil
+		}
+		return &ValidationError{
+			Message: "Error: Command does not specify a namespace; an explicit -n/--namespace flag is required when --allow-namespaces is configured",
+		}
 	}
 
 	return nil
+}
+
+// isNamespaceExemptOperation reports whether the given operation may be executed
+// without an explicit namespace even when --allow-namespaces is configured.
+func (v *Validator) isNamespaceExemptOperation(operation, commandType string) bool {
+	switch commandType {
+	case CommandTypeKubectl:
+		return kubectlNamespaceExemptOperations[operation]
+	case CommandTypeHelm:
+		return helmNamespaceExemptOperations[operation]
+	default:
+		// cilium / hubble are not gated by --allow-namespaces in this validator.
+		return true
+	}
 }
 
 // isOperationInList checks if an operation is in the given list
@@ -346,8 +407,13 @@ func (v *Validator) isConfigWriteOperation(command string) bool {
 // extractNamespaceFromCommand extracts the namespace from a command.
 // Returns "__AMBIGUOUS_NAMESPACE__" if multiple namespace flags are detected.
 func (v *Validator) extractNamespaceFromCommand(command string) string {
-	// Check for explicit namespace parameter
-	namespacePattern := `(?:-n|--namespace)[\s=]([^\s]+)`
+	// Check for explicit namespace parameter. Matches:
+	//   --namespace=value, --namespace value
+	//   -n=value, -n value, -nvalue (compact pflag short form)
+	// Anchoring on (^|\s) prevents `--namespace` from matching the substring
+	// inside other long flags (e.g. `--no-headers` would never reach here, but
+	// future flags starting with `--namespace...` should not collide either).
+	namespacePattern := `(?:^|\s)(?:--namespace[\s=]|-n[\s=]?)([^\s]+)`
 	re := regexp.MustCompile(namespacePattern)
 	allMatches := re.FindAllStringSubmatch(command, -1)
 

--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -3,6 +3,8 @@ package security
 import (
 	"regexp"
 	"strings"
+
+	"github.com/google/shlex"
 )
 
 // Command type constants
@@ -82,10 +84,13 @@ var (
 		"status", "version", "help", "observe", "status", "list", "config",
 	}
 
-	// kubectlNamespaceExemptOperations are kubectl operations that are not bound to
-	// a single namespace and may therefore be executed without an explicit -n flag
-	// even when --allow-namespaces is configured. These cover cluster-info /
-	// version / kubeconfig-style introspection and help commands.
+	// kubectlNamespaceExemptOperations are kubectl operations whose verbs are
+	// inherently not bound to a single namespace and may therefore be executed
+	// without an explicit -n flag even when --allow-namespaces is configured.
+	// These cover cluster-info / version / kubeconfig-style introspection and
+	// help commands. Verbs that can be either namespaced or cluster-scoped
+	// (get, describe, top, auth, label, annotate, delete, patch, ...) are
+	// NOT here -- those use kubectlClusterScopedResources instead.
 	kubectlNamespaceExemptOperations = map[string]bool{
 		"version":       true,
 		"cluster-info":  true,
@@ -99,7 +104,51 @@ var (
 		"explain":       true,
 	}
 
-	// helmNamespaceExemptOperations mirror kubectlNamespaceExemptOperations for helm.
+	// kubectlClusterScopedResources is the set of well-known cluster-scoped
+	// resource types. When a kubectl command targets only resources in this
+	// set, it does not act on any namespace and is exempt from
+	// --allow-namespaces enforcement even without an explicit -n flag.
+	//
+	// Keys are lowercased, singular/plural variants and common short names are
+	// all included so the lookup tolerates the forms users actually type.
+	// Anything not in this set is treated as namespaced for safety.
+	kubectlClusterScopedResources = map[string]bool{
+		// Cluster-scoped core API
+		"node": true, "nodes": true, "no": true,
+		"namespace": true, "namespaces": true, "ns": true,
+		"persistentvolume": true, "persistentvolumes": true, "pv": true,
+		"componentstatus": true, "componentstatuses": true, "cs": true,
+
+		// RBAC cluster-scoped
+		"clusterrole": true, "clusterroles": true,
+		"clusterrolebinding": true, "clusterrolebindings": true,
+
+		// Storage cluster-scoped
+		"storageclass": true, "storageclasses": true, "sc": true,
+		"volumeattachment": true, "volumeattachments": true,
+		"csinode": true, "csinodes": true,
+		"csidriver": true, "csidrivers": true,
+
+		// API & admission cluster-scoped
+		"customresourcedefinition": true, "customresourcedefinitions": true, "crd": true, "crds": true,
+		"apiservice": true, "apiservices": true,
+		"mutatingwebhookconfiguration": true, "mutatingwebhookconfigurations": true,
+		"validatingwebhookconfiguration": true, "validatingwebhookconfigurations": true,
+		"validatingadmissionpolicy": true, "validatingadmissionpolicies": true,
+		"validatingadmissionpolicybinding": true, "validatingadmissionpolicybindings": true,
+
+		// Cert / scheduling / networking cluster-scoped
+		"certificatesigningrequest": true, "certificatesigningrequests": true, "csr": true, "csrs": true,
+		"priorityclass": true, "priorityclasses": true, "pc": true,
+		"runtimeclass": true, "runtimeclasses": true,
+		"ingressclass": true, "ingressclasses": true,
+		"flowschema": true, "flowschemas": true,
+		"prioritylevelconfiguration": true, "prioritylevelconfigurations": true,
+	}
+
+	// helmNamespaceExemptOperations mirror kubectlNamespaceExemptOperations
+	// for helm. helm's namespaced commands (list/status/get/install/...) all
+	// honor -n, but the entries below operate on local config / repo state.
 	helmNamespaceExemptOperations = map[string]bool{
 		"version":    true,
 		"env":        true,
@@ -286,25 +335,59 @@ func (v *Validator) validateAccessLevel(command, commandType string) error {
 	return nil
 }
 
+// Sentinel namespace tokens returned by namespace extraction.
+const (
+	namespaceTokenAmbiguous     = "__AMBIGUOUS_NAMESPACE__"
+	namespaceTokenAllNamespaces = "*"
+)
+
+// tokenizeCommand splits a command string the same way the executor does
+// (shlex), so the validator's view of `-n value`, quoting and the `--`
+// separator matches what kubectl will actually receive. Falls back to
+// strings.Fields when shlex rejects the input (unterminated quotes etc.)
+// so validation still runs -- the executor will reject the broken input
+// downstream.
+func tokenizeCommand(command string) []string {
+	if tokens, err := shlex.Split(command); err == nil {
+		return tokens
+	}
+	return strings.Fields(command)
+}
+
+// splitArgsAtDoubleDash returns the slice of tokens up to (but excluding)
+// a free-standing "--" separator. kubectl uses "--" to mark the start of
+// arguments that should be passed to the child process (e.g. the inner
+// `sh -c '...'` of `kubectl exec mypod -- ...`). Anything past "--" is not
+// a kubectl flag and must not influence namespace / scope decisions.
+func splitArgsAtDoubleDash(tokens []string) []string {
+	for i, t := range tokens {
+		if t == "--" {
+			return tokens[:i]
+		}
+	}
+	return tokens
+}
+
 // validateNamespaceScope validates if a command's namespace scope is allowed by security settings
 func (v *Validator) validateNamespaceScope(command, commandType string) error {
-	// Extract namespace from command
-	namespace := v.extractNamespaceFromCommand(command)
+	tokens := splitArgsAtDoubleDash(tokenizeCommand(command))
+
+	namespace := extractNamespaceFromTokens(tokens)
 
 	// Reject commands with multiple (ambiguous) namespace flags
-	if namespace == "__AMBIGUOUS_NAMESPACE__" {
+	if namespace == namespaceTokenAmbiguous {
 		return &ValidationError{Message: "Error: Command contains multiple namespace flags which is not allowed"}
 	}
 
 	hasRestrictions := len(v.secConfig.allowedNamespaces) > 0 || len(v.secConfig.allowedNamespacesRe) > 0
 
 	// If command applies to all namespaces, and there are namespace restrictions
-	if namespace == "*" && hasRestrictions {
+	if namespace == namespaceTokenAllNamespaces && hasRestrictions {
 		return &ValidationError{Message: "Error: Access to all namespaces is restricted by security configuration"}
 	}
 
-	// If a namespace is specified (or default "default" is used), check if it's allowed
-	if namespace != "" && namespace != "*" {
+	// If a namespace is specified, check if it's allowed
+	if namespace != "" && namespace != namespaceTokenAllNamespaces {
 		if !v.secConfig.IsNamespaceAllowed(namespace) {
 			return &ValidationError{
 				Message: "Error: Access to namespace '" + namespace + "' is denied by security configuration",
@@ -316,11 +399,9 @@ func (v *Validator) validateNamespaceScope(command, commandType string) error {
 	// No explicit namespace was found. When allowlist restrictions are active,
 	// commands without an explicit namespace would otherwise execute in the
 	// kubeconfig current namespace, which silently bypasses the allowlist.
-	// Reject these unless the operation is cluster-scoped or non-resource (e.g.
-	// kubectl version, kubectl cluster-info, kubectl config ...).
+	// Reject these unless the command is inherently namespace-independent.
 	if namespace == "" && hasRestrictions {
-		operation := v.extractOperationFromCommand(command, commandType)
-		if v.isNamespaceExemptOperation(operation, commandType) {
+		if v.isCommandNamespaceExempt(tokens, commandType) {
 			return nil
 		}
 		return &ValidationError{
@@ -331,18 +412,130 @@ func (v *Validator) validateNamespaceScope(command, commandType string) error {
 	return nil
 }
 
-// isNamespaceExemptOperation reports whether the given operation may be executed
-// without an explicit namespace even when --allow-namespaces is configured.
-func (v *Validator) isNamespaceExemptOperation(operation, commandType string) bool {
+// isCommandNamespaceExempt reports whether a command may run without an
+// explicit -n / --namespace flag even when --allow-namespaces is configured.
+// A command is exempt when either:
+//
+//   - its operation verb is in the *NamespaceExemptOperations table (verbs
+//     that never touch a namespace, e.g. kubectl version, helm repo, ...), or
+//   - (kubectl only) every resource reference in the command targets a
+//     cluster-scoped resource (kubectl get nodes, kubectl get pv, kubectl get
+//     clusterrole/foo, ...).
+//
+// Anything ambiguous (unknown resource type, no resource type at all) is
+// NOT exempt, so the default behavior is to require -n.
+func (v *Validator) isCommandNamespaceExempt(tokens []string, commandType string) bool {
+	operation := extractOperationFromTokens(tokens, commandType)
+
 	switch commandType {
 	case CommandTypeKubectl:
-		return kubectlNamespaceExemptOperations[operation]
+		if kubectlNamespaceExemptOperations[operation] {
+			return true
+		}
+		return kubectlOnlyTargetsClusterScopedResources(tokens, operation)
 	case CommandTypeHelm:
 		return helmNamespaceExemptOperations[operation]
 	default:
 		// cilium / hubble are not gated by --allow-namespaces in this validator.
 		return true
 	}
+}
+
+// kubectlOnlyTargetsClusterScopedResources returns true iff the command
+// references one or more resource types AND every referenced resource type
+// is known cluster-scoped. Examples:
+//
+//	kubectl get nodes                       -> true  (nodes is cluster-scoped)
+//	kubectl get nodes,pv                    -> true  (both cluster-scoped)
+//	kubectl get clusterrole/admin           -> true  (resource/name form)
+//	kubectl get pods                        -> false (pods is namespaced)
+//	kubectl get nodes pods                  -> false (mixed)
+//	kubectl get -f manifest.yaml            -> false (no resource type to inspect)
+//	kubectl auth can-i get pods             -> false (verb arg, not a resource)
+//	kubectl logs mypod                      -> false (mypod is a name, no type)
+func kubectlOnlyTargetsClusterScopedResources(tokens []string, operation string) bool {
+	// Only well-understood read/inspect verbs are eligible. Mutation verbs
+	// like "label" or "delete" take resources too, but until we model the
+	// argument grammar carefully we conservatively require -n for them.
+	resourceVerbs := map[string]bool{
+		"get": true, "describe": true, "top": true, "edit": true, "wait": true,
+	}
+	if !resourceVerbs[operation] {
+		return false
+	}
+
+	resourceArgs := collectResourceArgs(tokens, operation)
+	if len(resourceArgs) == 0 {
+		return false
+	}
+
+	// kubectl's grammar: the first positional after the verb is the resource
+	// type (or a comma-separated list of types, or a TYPE/NAME pair).
+	// Subsequent positionals are names. We only inspect the first.
+	for _, rt := range splitResourceTypes(resourceArgs[0]) {
+		if !kubectlClusterScopedResources[strings.ToLower(rt)] {
+			return false
+		}
+	}
+	return true
+}
+
+// collectResourceArgs returns the positional arguments that follow the
+// operation verb, stopping at flags and at the first arg that is purely a
+// name (no type). For "kubectl get nodes node1 -o yaml" it returns
+// ["nodes", "node1"]; for "kubectl get nodes,pv" it returns ["nodes,pv"].
+// Flag values (`-o yaml`, `-l app=x`, `--field-selector=...`) are skipped.
+func collectResourceArgs(tokens []string, operation string) []string {
+	flagsTakingValues := map[string]bool{
+		"-o": true, "--output": true,
+		"-l": true, "--selector": true,
+		"--field-selector":      true,
+		"--chunk-size":          true,
+		"--show-managed-fields": true,
+		"--sort-by":             true,
+		"--template":            true,
+		"--server-print":        true,
+		"--for":                 true,
+	}
+
+	var out []string
+	seenOp := false
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+		if !seenOp {
+			if t == operation {
+				seenOp = true
+			}
+			continue
+		}
+		if strings.HasPrefix(t, "-") {
+			// Flag. Skip its value if it takes a separate argument and isn't using "=".
+			if !strings.Contains(t, "=") && flagsTakingValues[t] && i+1 < len(tokens) {
+				i++
+			}
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// splitResourceTypes turns a resource argument into the list of resource
+// types it references. "nodes,pv" -> ["nodes", "pv"]; "clusterrole/admin"
+// -> ["clusterrole"]; "node1" -> ["node1"] (just a name -- caller must
+// decide what to do with bare names).
+func splitResourceTypes(arg string) []string {
+	parts := strings.Split(arg, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if i := strings.Index(p, "/"); i >= 0 {
+			p = p[:i]
+		}
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // isOperationInList checks if an operation is in the given list
@@ -357,20 +550,22 @@ func (v *Validator) isOperationInList(operation string, allowedOperations []stri
 
 // extractOperationFromCommand extracts the operation from a command
 func (v *Validator) extractOperationFromCommand(command, commandType string) string {
-	cmdParts := strings.Fields(command)
-	var operation string
+	return extractOperationFromTokens(splitArgsAtDoubleDash(tokenizeCommand(command)), commandType)
+}
 
-	for _, part := range cmdParts {
-		if !strings.HasPrefix(part, "-") {
-			// Skip the initial command name (kubectl, helm, cilium)
-			if part != commandType {
-				operation = part
-				break
-			}
+// extractOperationFromTokens returns the first positional token after the
+// command name (skipping flags). For "kubectl get pods -n x" -> "get".
+func extractOperationFromTokens(tokens []string, commandType string) string {
+	for _, part := range tokens {
+		if strings.HasPrefix(part, "-") {
+			continue
 		}
+		if part == commandType {
+			continue
+		}
+		return part
 	}
-
-	return operation
+	return ""
 }
 
 // isConfigWriteOperation checks if a config command is a write operation
@@ -404,40 +599,89 @@ func (v *Validator) isConfigWriteOperation(command string) bool {
 	return false
 }
 
-// extractNamespaceFromCommand extracts the namespace from a command.
-// Returns "__AMBIGUOUS_NAMESPACE__" if multiple namespace flags are detected.
-func (v *Validator) extractNamespaceFromCommand(command string) string {
-	// Check for explicit namespace parameter. Matches:
-	//   --namespace=value, --namespace value
-	//   -n=value, -n value, -nvalue (compact pflag short form)
-	// Anchoring on (^|\s) prevents `--namespace` from matching the substring
-	// inside other long flags (e.g. `--no-headers` would never reach here, but
-	// future flags starting with `--namespace...` should not collide either).
-	namespacePattern := `(?:^|\s)(?:--namespace[\s=]|-n[\s=]?)([^\s]+)`
-	re := regexp.MustCompile(namespacePattern)
-	allMatches := re.FindAllStringSubmatch(command, -1)
+// extractNamespaceFromTokens scans a pre-tokenized command for the
+// namespace flag. Only flag tokens are inspected, so a `-n` that appears
+// inside `kubectl exec ... -- grep -n foo file` (already trimmed by the
+// caller via splitArgsAtDoubleDash) and a literal `-n` value within an
+// `--option=value` style flag (token contains "=") are correctly ignored.
+//
+// Supported forms (all in a *single* flag token or a flag/value pair):
+//
+//	--namespace=value
+//	--namespace value
+//	-n=value
+//	-n value
+//	-nvalue          (compact pflag short form)
+//
+// All-namespaces forms: --all-namespaces / --all-namespaces=true|false / -A.
+func extractNamespaceFromTokens(tokens []string) string {
+	var (
+		nsValues []string
+		allNs    bool
+	)
 
-	if len(allMatches) > 1 {
-		// Multiple namespace flags are ambiguous and potentially malicious
-		return "__AMBIGUOUS_NAMESPACE__"
-	}
-	if len(allMatches) == 1 {
-		return allMatches[0][1]
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+
+		switch {
+		case t == "--all-namespaces" || t == "-A":
+			allNs = true
+			continue
+		case strings.HasPrefix(t, "--all-namespaces="):
+			v := strings.TrimPrefix(t, "--all-namespaces=")
+			if v != "false" && v != "0" {
+				allNs = true
+			}
+			continue
+		}
+
+		// --namespace forms
+		if t == "--namespace" {
+			if i+1 < len(tokens) {
+				nsValues = append(nsValues, tokens[i+1])
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(t, "--namespace=") {
+			nsValues = append(nsValues, strings.TrimPrefix(t, "--namespace="))
+			continue
+		}
+
+		// -n short forms
+		if t == "-n" {
+			if i+1 < len(tokens) {
+				nsValues = append(nsValues, tokens[i+1])
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(t, "-n=") {
+			nsValues = append(nsValues, strings.TrimPrefix(t, "-n="))
+			continue
+		}
+		// Compact form `-nVALUE`. Restrict to tokens that start with literal
+		// "-n" but are NOT another long flag like "--node-selector" and not
+		// "-nA"/"-no" etc combined with other short flags. We require the
+		// next character to be present and the token length > 2.
+		if len(t) > 2 && strings.HasPrefix(t, "-n") && !strings.HasPrefix(t, "--") {
+			nsValues = append(nsValues, t[2:])
+			continue
+		}
 	}
 
-	// Check if there's a format like <resource>/<name>
-	resourcePattern := `(\S+)/(\S+)`
-	re = regexp.MustCompile(resourcePattern)
-	if re.MatchString(command) {
-		// If the command contains resource/name format but no explicit namespace,
-		// the default namespace "default" will be used
-		return "default"
+	if len(nsValues) > 1 {
+		return namespaceTokenAmbiguous
 	}
-
-	// Check for --all-namespaces or -A
-	if strings.Contains(command, "--all-namespaces") || strings.Contains(command, " -A") || strings.HasSuffix(command, " -A") {
-		return "*" // Special marker indicating all namespaces
+	if len(nsValues) == 1 {
+		if allNs {
+			// Conflict: both -n X and --all-namespaces specified.
+			return namespaceTokenAmbiguous
+		}
+		return nsValues[0]
 	}
-
-	return "" // No namespace found, default namespace will be used
+	if allNs {
+		return namespaceTokenAllNamespaces
+	}
+	return ""
 }

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -578,10 +578,12 @@ func TestClusterScopedResourcesAllowedWithoutNamespace(t *testing.T) {
 
 	// Mixed cluster-scoped + namespaced resources are NOT exempt.
 	blocked := []string{
-		"kubectl get nodes,pods",          // mixed
+		"kubectl get nodes,pods",          // mixed via comma
+		"kubectl get node/n1 pod/p1",      // mixed via multiple resource/name positionals
 		"kubectl get pods",                // namespaced
 		"kubectl describe pod mypod",      // namespaced
 		"kubectl get pod/mypod",           // namespaced via resource/name
+		"kubectl get widget/foo",          // unknown type -> assume namespaced
 		"kubectl auth can-i get pods",     // verb arg, not a resource
 		"kubectl logs mypod",              // logs always targets a pod (namespaced)
 		"kubectl label node node1 env=x",  // mutation verbs are not in the exempt verb set

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -139,7 +139,12 @@ func TestNamespaceHandling(t *testing.T) {
 	}{
 		{"kubectl get pods -n test-ns", false, ""},
 		{"kubectl get pods --namespace=another-ns", false, ""},
-		{"kubectl get pod/mypod", false, ""},
+		// resource/name without an explicit -n no longer silently defaults
+		// to "default" (that was a bypass when "default" was in the
+		// allowlist). It must be rejected, the same as bare "kubectl get
+		// pods", because pod is a namespaced resource and the actual
+		// namespace would come from kubeconfig.
+		{"kubectl get pod/mypod", true, "explicit -n"},
 		{"kubectl get pods -n disallowed-ns", true, "denied by security configuration"},
 		{"kubectl get pods --all-namespaces", true, "restricted by security configuration"},
 		{"kubectl get pods -A", true, "restricted by security configuration"},
@@ -436,6 +441,176 @@ func TestNamespaceNoRestrictionsAllowsEmptyNamespace(t *testing.T) {
 	for _, c := range commands {
 		if err := validator.ValidateCommand(c.cmd, c.kind); err != nil {
 			t.Errorf("unrestricted config should allow %q, got: %v", c.cmd, err)
+		}
+	}
+}
+
+// TestNamespaceResourceSlashBypass — review comment #1 on PR #141.
+// extractNamespaceFromCommand previously returned "default" for any command
+// containing a resource/name token, so with an allowlist that contained
+// "default" (a common configuration), commands like `kubectl get
+// secret/mysecret` silently bypassed the allowlist and ran in the
+// kubeconfig current namespace. Additionally, `kubectl get deploy/myapp -A`
+// hit the resource/name branch BEFORE the --all-namespaces check ran, so it
+// was evaluated as a single namespace rather than as all-namespaces.
+func TestNamespaceResourceSlashBypass(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.SetAllowedNamespaces("default,production")
+	secConfig.AccessLevel = AccessLevelReadWrite
+	validator := NewValidator(secConfig)
+
+	tests := []struct {
+		name        string
+		command     string
+		shouldBlock bool
+	}{
+		// resource/name without -n must NOT silently default to "default"
+		// just because "default" is in the allowlist.
+		{"resource/name no ns", "kubectl get secret/mysecret", true},
+		{"resource/name delete", "kubectl delete secret/mysecret", true},
+		// --all-namespaces must take precedence over resource/name parsing.
+		{"resource/name -A", "kubectl get deploy/myapp -A", true},
+		{"resource/name --all-namespaces", "kubectl get deploy/myapp --all-namespaces", true},
+		// Explicit ns is still respected.
+		{"resource/name -n allowed", "kubectl get secret/mysecret -n production", false},
+		{"resource/name -n denied", "kubectl get secret/mysecret -n kube-system", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.ValidateCommand(tc.command, CommandTypeKubectl)
+			if tc.shouldBlock && err == nil {
+				t.Errorf("expected block, got allow: %q", tc.command)
+			}
+			if !tc.shouldBlock && err != nil {
+				t.Errorf("expected allow, got block: %q: %v", tc.command, err)
+			}
+		})
+	}
+}
+
+// TestNamespaceFlagInsideExecArgs — review comment #2 on PR #141.
+// The old regex matched -n / --namespace anywhere in the string, including
+// inside the inner arguments of `kubectl exec ... -- ...`. That meant:
+//
+//   - benign inner `-n` (e.g. `grep -n`) made the validator parse a wrong
+//     namespace from arbitrary text, blocking legitimate commands;
+//   - crafted payloads like `... -- sh -c '... -n production ...'` made the
+//     validator believe the namespace was allowed, while the real exec ran
+//     in the kubeconfig current namespace.
+//
+// The fix tokenizes with shlex and ignores everything after a free-standing
+// "--" separator.
+func TestNamespaceFlagInsideExecArgs(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.SetAllowedNamespaces("production")
+	secConfig.AccessLevel = AccessLevelReadWrite
+	validator := NewValidator(secConfig)
+
+	// Inner `-n` in grep args must NOT be parsed as the kube namespace.
+	// Because the command itself doesn't specify a namespace and exec is
+	// namespaced, this is rejected by the "needs explicit -n" rule -- the
+	// important thing is that it is NOT rejected with a "namespace foo is
+	// denied" message that would betray the buggy parse.
+	err := validator.ValidateCommand("kubectl exec mypod -- grep -n foo file", CommandTypeKubectl)
+	if err == nil {
+		t.Errorf("exec without -n should be rejected when allowlist is configured")
+	} else if strings.Contains(err.Error(), "namespace 'foo'") {
+		t.Errorf("inner '-n foo' must not be parsed as kube namespace: %v", err)
+	}
+
+	// Crafted payload: attacker-controlled inner string contains
+	// "-n production". The real exec still runs in the kubeconfig current
+	// namespace, so the validator must NOT be fooled into approving it.
+	err = validator.ValidateCommand(
+		"kubectl exec mypod -- sh -c 'do_evil -n production'",
+		CommandTypeKubectl,
+	)
+	if err == nil {
+		t.Errorf("crafted inner -n production must not bypass --allow-namespaces")
+	}
+
+	// Adding an outer explicit -n makes it legitimate. Inner -n is still ignored.
+	err = validator.ValidateCommand(
+		"kubectl exec mypod -n production -- grep -n foo file",
+		CommandTypeKubectl,
+	)
+	if err != nil {
+		t.Errorf("legitimate exec with outer -n production should be allowed, got: %v", err)
+	}
+}
+
+// TestClusterScopedResourcesAllowedWithoutNamespace — review comment #3 on
+// PR #141. The verb-keyed exempt set (`version`, `cluster-info`, ...) does
+// not cover routine cluster-scoped read commands like `kubectl get nodes`,
+// because they use the same `get`/`top`/`auth` verbs as namespaced reads.
+// The fix adds a cluster-scoped resource set so these commands stay
+// allowed without -n.
+func TestClusterScopedResourcesAllowedWithoutNamespace(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.SetAllowedNamespaces("production")
+	secConfig.AccessLevel = AccessLevelReadWrite
+	validator := NewValidator(secConfig)
+
+	allowed := []string{
+		"kubectl get nodes",
+		"kubectl get no",
+		"kubectl get pv",
+		"kubectl get persistentvolumes",
+		"kubectl get namespaces",
+		"kubectl get ns",
+		"kubectl get clusterroles",
+		"kubectl get clusterrolebindings",
+		"kubectl get storageclass",
+		"kubectl get crd",
+		"kubectl get csr",
+		"kubectl get priorityclasses",
+		"kubectl top nodes",
+		"kubectl describe node node1",
+		"kubectl get nodes,pv",         // multi-type, all cluster-scoped
+		"kubectl get clusterrole/admin", // resource/name on cluster-scoped type
+	}
+	for _, c := range allowed {
+		if err := validator.ValidateCommand(c, CommandTypeKubectl); err != nil {
+			t.Errorf("cluster-scoped read should be allowed without -n: %q: %v", c, err)
+		}
+	}
+
+	// Mixed cluster-scoped + namespaced resources are NOT exempt.
+	blocked := []string{
+		"kubectl get nodes,pods",          // mixed
+		"kubectl get pods",                // namespaced
+		"kubectl describe pod mypod",      // namespaced
+		"kubectl get pod/mypod",           // namespaced via resource/name
+		"kubectl auth can-i get pods",     // verb arg, not a resource
+		"kubectl logs mypod",              // logs always targets a pod (namespaced)
+		"kubectl label node node1 env=x",  // mutation verbs are not in the exempt verb set
+		"kubectl delete node node1",       // mutation verbs are not in the exempt verb set
+	}
+	for _, c := range blocked {
+		if err := validator.ValidateCommand(c, CommandTypeKubectl); err == nil {
+			t.Errorf("expected block (namespaced or mixed), got allow: %q", c)
+		}
+	}
+}
+
+// TestAllNamespacesPlusExplicitNamespaceIsAmbiguous — when a command
+// contains both --all-namespaces and -n X, the intent is ambiguous and
+// should be rejected rather than silently honoring one form.
+func TestAllNamespacesPlusExplicitNamespaceIsAmbiguous(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.SetAllowedNamespaces("production")
+	validator := NewValidator(secConfig)
+
+	cases := []string{
+		"kubectl get pods -A -n production",
+		"kubectl get pods --all-namespaces -n production",
+		"kubectl get pods --all-namespaces --namespace=production",
+	}
+	for _, c := range cases {
+		err := validator.ValidateCommand(c, CommandTypeKubectl)
+		if err == nil {
+			t.Errorf("ambiguous all-namespaces+explicit must be rejected: %q", c)
 		}
 	}
 }

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -343,3 +343,99 @@ func TestNamespaceBypassPrevention(t *testing.T) {
 		})
 	}
 }
+
+// TestNamespaceNoFlagBypass covers the MSRC report where commands without an
+// explicit -n / --namespace flag silently bypassed --allow-namespaces and
+// executed in the kubeconfig current namespace. The expected behavior is:
+//   - When an allowlist is configured, namespaced operations without -n are
+//     rejected.
+//   - Cluster-scoped / non-resource operations (version, cluster-info, config,
+//     api-resources, help, etc.) remain allowed.
+//   - Compact short-flag form `-nVALUE` is parsed and validated.
+func TestNamespaceNoFlagBypass(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.SetAllowedNamespaces("production")
+	secConfig.AccessLevel = AccessLevelReadWrite
+	validator := NewValidator(secConfig)
+
+	tests := []struct {
+		name        string
+		command     string
+		commandType string
+		shouldBlock bool
+	}{
+		// Explicit allowed namespace: pass through
+		{"explicit allowed ns", "kubectl get pods -n production", CommandTypeKubectl, false},
+		{"explicit allowed --namespace=", "kubectl get pods --namespace=production", CommandTypeKubectl, false},
+
+		// Explicit disallowed namespace: blocked
+		{"explicit disallowed ns", "kubectl get pods -n default", CommandTypeKubectl, true},
+		{"--namespace=disallowed", "kubectl get pods --namespace=default", CommandTypeKubectl, true},
+		{"--all-namespaces", "kubectl get pods --all-namespaces", CommandTypeKubectl, true},
+		{"-A short form", "kubectl get pods -A", CommandTypeKubectl, true},
+
+		// No-flag bypass: now blocked
+		{"no flag get secrets", "kubectl get secrets", CommandTypeKubectl, true},
+		{"no flag get pods", "kubectl get pods", CommandTypeKubectl, true},
+		{"no flag create secret", "kubectl create secret generic pwned --from-literal=x=y", CommandTypeKubectl, true},
+		{"no flag apply -f", "kubectl apply -f deployment.yaml", CommandTypeKubectl, true},
+		{"no flag get configmaps", "kubectl get configmaps", CommandTypeKubectl, true},
+		{"no flag describe secret", "kubectl describe secret mysecret", CommandTypeKubectl, true},
+		{"no flag logs", "kubectl logs mypod", CommandTypeKubectl, true},
+		{"no flag delete secret", "kubectl delete secret mysecret", CommandTypeKubectl, true},
+		{"no flag scale", "kubectl scale deployment myapp --replicas=3", CommandTypeKubectl, true},
+		{"no flag helm list", "helm list", CommandTypeHelm, true},
+		{"no flag helm status", "helm status myapp", CommandTypeHelm, true},
+
+		// Compact -nVALUE form: parsed and enforced
+		{"compact -nVALUE disallowed", "kubectl get secrets -ndefault", CommandTypeKubectl, true},
+		{"compact -nVALUE allowed", "kubectl get secrets -nproduction", CommandTypeKubectl, false},
+
+		// Cluster-scoped / non-resource operations: allowed without -n
+		{"version no ns", "kubectl version", CommandTypeKubectl, false},
+		{"cluster-info no ns", "kubectl cluster-info", CommandTypeKubectl, false},
+		{"api-resources no ns", "kubectl api-resources", CommandTypeKubectl, false},
+		{"api-versions no ns", "kubectl api-versions", CommandTypeKubectl, false},
+		{"config get-contexts no ns", "kubectl config get-contexts", CommandTypeKubectl, false},
+		{"explain pods no ns", "kubectl explain pods", CommandTypeKubectl, false},
+		{"helm version no ns", "helm version", CommandTypeHelm, false},
+		{"helm repo list no ns", "helm repo list", CommandTypeHelm, false},
+		{"helm search no ns", "helm search repo nginx", CommandTypeHelm, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validator.ValidateCommand(tc.command, tc.commandType)
+			if tc.shouldBlock && err == nil {
+				t.Errorf("expected block, got allow: %q", tc.command)
+			}
+			if !tc.shouldBlock && err != nil {
+				t.Errorf("expected allow, got block: %q: %v", tc.command, err)
+			}
+		})
+	}
+}
+
+// TestNamespaceNoRestrictionsAllowsEmptyNamespace makes sure that when no
+// --allow-namespaces is configured we keep the historical permissive behavior:
+// commands without -n are accepted (kubectl uses the kubeconfig current ns).
+func TestNamespaceNoRestrictionsAllowsEmptyNamespace(t *testing.T) {
+	secConfig := NewSecurityConfig()
+	secConfig.AccessLevel = AccessLevelReadWrite
+	validator := NewValidator(secConfig)
+
+	commands := []struct {
+		cmd  string
+		kind string
+	}{
+		{"kubectl get pods", CommandTypeKubectl},
+		{"kubectl get secrets", CommandTypeKubectl},
+		{"kubectl apply -f deployment.yaml", CommandTypeKubectl},
+		{"helm list", CommandTypeHelm},
+	}
+	for _, c := range commands {
+		if err := validator.ValidateCommand(c.cmd, c.kind); err != nil {
+			t.Errorf("unrestricted config should allow %q, got: %v", c.cmd, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Reject namespaced kubectl/helm commands that omit `-n`/`--namespace` when `--allow-namespaces` is configured (previously they fell through and executed in the kubeconfig current namespace, silently bypassing the allowlist).
- Exempt a small set of cluster-scoped / non-resource operations (`version`, `cluster-info`, `api-resources`, `api-versions`, `config`, `explain`, `help`, helm `repo`/`search`/`env`/...) so diagnostic commands still work without `-n`.
- Parse the compact short-flag form `-nVALUE` (e.g. `-ndefault`) — the prior regex only matched `-n value` / `-n=value`, so `-ndefault` was treated as no namespace and bypassed the allowlist.

Internal MSRC assessment: `msrc/msrc-assessment-namespace-noflag-bypass.md` (Low / defense-in-depth, consistent with prior reports — RBAC remains the authoritative authorization boundary). No CVE requested.

## Test plan

- [x] `go test ./pkg/security/...` — all green
- [x] `go test ./...` — all green
- [x] New `TestNamespaceNoFlagBypass` covers every command class from the report (read/write kubectl, helm list/status, compact `-nVALUE`) plus the cluster-scoped exemptions
- [x] New `TestNamespaceNoRestrictionsAllowsEmptyNamespace` guards that unrestricted configurations still allow commands without `-n` (no behavior regression for users not using `--allow-namespaces`)