### PR TITLE
fix(security): block kubectl auth reconcile in readonly mode

### DIFF
--- a/pkg/security/validator.go
+++ b/pkg/security/validator.go
@@ -303,6 +303,14 @@ func (v *Validator) validateAccessLevel(command, commandType string) error {
 		if operation == "config" && v.isConfigWriteOperation(command) {
 			return &ValidationError{Message: "Error: Cannot execute config write operations in read-only mode"}
 		}
+		// Special handling for auth operations - "auth" is a read-only verb
+		// for subcommands like "auth can-i" / "auth whoami", but "auth reconcile"
+		// creates/updates RBAC roles and bindings and is therefore a write
+		// operation. Reject it in read-only mode regardless of the broader
+		// "auth" classification.
+		if operation == "auth" && v.isAuthWriteOperation(command, commandType) {
+			return &ValidationError{Message: "Error: Cannot execute auth write operations (e.g. 'auth reconcile') in read-only mode"}
+		}
 		if !v.isOperationInList(operation, readOperations) {
 			return &ValidationError{Message: "Error: Cannot execute write or admin operations in read-only mode"}
 		}
@@ -584,6 +592,43 @@ func extractOperationFromTokens(tokens []string, commandType string) string {
 		return part
 	}
 	return ""
+}
+
+// isAuthWriteOperation reports whether an `<command-type> auth ...` command
+// is a write operation. Currently this captures `kubectl auth reconcile`,
+// which creates/updates RBAC Role / RoleBinding / ClusterRole /
+// ClusterRoleBinding objects from a manifest. Other auth subcommands
+// (`can-i`, `whoami`) are read-only and remain allowed in readonly mode.
+//
+// Only kubectl has an `auth` subcommand grammar today; helm/cilium/hubble
+// also list "auth" as a read operation in some contexts but do not have a
+// reconcile equivalent, so for those we treat all auth subcommands as read.
+func (v *Validator) isAuthWriteOperation(command, commandType string) bool {
+	if commandType != CommandTypeKubectl {
+		return false
+	}
+	tokens := splitArgsAtDoubleDash(tokenizeCommand(command))
+	// Find the "auth" verb position (after skipping the optional "kubectl"
+	// prefix and any global flags), then look at the next positional token.
+	seenAuth := false
+	for i := 0; i < len(tokens); i++ {
+		t := tokens[i]
+		if strings.HasPrefix(t, "-") {
+			continue
+		}
+		if !seenAuth {
+			if t == "auth" {
+				seenAuth = true
+			}
+			continue
+		}
+		// First positional after "auth" is the subcommand.
+		if t == "reconcile" {
+			return true
+		}
+		return false
+	}
+	return false
 }
 
 // isConfigWriteOperation checks if a config command is a write operation

--- a/pkg/security/validator_test.go
+++ b/pkg/security/validator_test.go
@@ -78,6 +78,19 @@ func TestValidatorAccessLevels(t *testing.T) {
 		{"Admin - config set-context", AccessLevelAdmin, "config set-context myctx", false, ""},
 		{"Admin - config set-cluster", AccessLevelAdmin, "config set-cluster mycluster", false, ""},
 		{"Admin - config set-credentials", AccessLevelAdmin, "config set-credentials myuser", false, ""},
+
+		// Auth subcommand tests (MSRC 31000000636528). "auth" is in the
+		// read-only operation list because "auth can-i" / "auth whoami" are
+		// read-only, but "auth reconcile" creates/updates RBAC objects and
+		// must be treated as a write operation.
+		{"ReadOnly - auth can-i", AccessLevelReadOnly, "auth can-i create pods", false, ""},
+		{"ReadOnly - auth whoami", AccessLevelReadOnly, "auth whoami", false, ""},
+		{"ReadOnly - auth reconcile blocked", AccessLevelReadOnly, "auth reconcile -f rbac.yaml", true, "auth write operations"},
+		{"ReadOnly - auth reconcile with kubectl prefix blocked", AccessLevelReadOnly, "kubectl auth reconcile -f rbac.yaml", true, "auth write operations"},
+		{"ReadOnly - auth reconcile with leading flags blocked", AccessLevelReadOnly, "kubectl -v=2 auth reconcile -f rbac.yaml", true, "auth write operations"},
+		{"ReadWrite - auth can-i", AccessLevelReadWrite, "auth can-i create pods", false, ""},
+		{"ReadWrite - auth reconcile allowed", AccessLevelReadWrite, "auth reconcile -f rbac.yaml", false, ""},
+		{"Admin - auth reconcile allowed", AccessLevelAdmin, "auth reconcile -f rbac.yaml", false, ""},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

The `auth` verb is in `KubectlReadOperations` because `auth can-i` and `auth whoami` are read-only queries. However, `kubectl auth reconcile` creates or updates RBAC `Role` / `RoleBinding` / `ClusterRole` / `ClusterRoleBinding` objects from a manifest, so the broad `auth` classification leaks a write capability into readonly mode.

This mirrors the existing `config` write subcommand handling: in readonly mode, after the operation is identified as `auth`, check the subcommand. Reject `reconcile`; let `can-i` / `whoami` (and any other auth subcommand) through. ReadWrite and admin modes are unchanged — `reconcile` is a legitimate write operation there.

## Test plan

- [x] `go test ./pkg/security/...` — all green
- [x] `go test ./...` — all green
- [x] New table-driven cases in `TestValidatorAccessLevels` cover:
  - readonly blocks `auth reconcile -f rbac.yaml` (with and without `kubectl` prefix, and with leading global flags like `-v=2`)
  - readonly allows `auth can-i` / `auth whoami`
  - readwrite/admin allow `auth reconcile`