### PR TITLE
feat(server): validate Host and Origin headers on HTTP transports

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,14 @@ type ConfigData struct {
 	AccessLevel     string
 	AllowNamespaces string
 
+	// Additional Host header values to trust for HTTP transports (comma-separated).
+	// Loopback names and the configured --host are always trusted.
+	AllowHosts string
+	// Origin header values to trust for HTTP transports (comma-separated).
+	// When an Origin header is present it must match one of these; browser
+	// origins are rejected by default to defend against DNS-rebinding.
+	AllowOrigins string
+
 	// OTLP endpoint for OpenTelemetry traces
 	OTLPEndpoint string
 
@@ -69,6 +77,15 @@ func (cfg *ConfigData) ParseFlags() error {
 	flag.StringVar(&cfg.AccessLevel, "access-level", "readonly", "Access level (readonly, readwrite, or admin)")
 	flag.StringVar(&cfg.AllowNamespaces, "allow-namespaces", "",
 		"Comma-separated list of namespaces to allow (empty means all allowed)")
+
+	// HTTP transport hardening (sse / streamable-http only)
+	flag.StringVar(&cfg.AllowHosts, "allow-hosts", "",
+		"Comma-separated list of additional Host header values to trust for HTTP transports. "+
+			"Loopback hosts and the configured --host are always trusted. Supports '*' wildcard to disable the check.")
+	flag.StringVar(&cfg.AllowOrigins, "allow-origins", "",
+		"Comma-separated list of Origin header values to trust for HTTP transports. "+
+			"Requests carrying any other Origin header are rejected to defend against DNS-rebinding. "+
+			"Supports '*' wildcard to disable the check.")
 
 	// OTLP settings
 	flag.StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP endpoint for OpenTelemetry traces (e.g. localhost:4317, default \"\")")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,8 +33,8 @@ type ConfigData struct {
 	// Loopback names and the configured --host are always trusted.
 	AllowHosts string
 	// Origin header values to trust for HTTP transports (comma-separated).
-	// When an Origin header is present it must match one of these; browser
-	// origins are rejected by default to defend against DNS-rebinding.
+	// Loopback origins are always trusted; any other present Origin header is
+	// rejected by default to defend against DNS-rebinding.
 	AllowOrigins string
 
 	// OTLP endpoint for OpenTelemetry traces
@@ -81,10 +81,11 @@ func (cfg *ConfigData) ParseFlags() error {
 	// HTTP transport hardening (sse / streamable-http only)
 	flag.StringVar(&cfg.AllowHosts, "allow-hosts", "",
 		"Comma-separated list of additional Host header values to trust for HTTP transports. "+
-			"Loopback hosts and the configured --host are always trusted. Supports '*' wildcard to disable the check.")
+			"Loopback hosts and the configured --host (unless it is a 0.0.0.0/:: wildcard) are always trusted. "+
+			"Supports '*' wildcard to disable the check.")
 	flag.StringVar(&cfg.AllowOrigins, "allow-origins", "",
 		"Comma-separated list of Origin header values to trust for HTTP transports. "+
-			"Requests carrying any other Origin header are rejected to defend against DNS-rebinding. "+
+			"Loopback origins are always trusted; any other Origin header is rejected to defend against DNS-rebinding. "+
 			"Supports '*' wildcard to disable the check.")
 
 	// OTLP settings

--- a/pkg/server/httpguard.go
+++ b/pkg/server/httpguard.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// hostOriginGuard is an http.Handler middleware that protects the HTTP-based
+// MCP transports (streamable-http and sse) against DNS-rebinding attacks.
+//
+// A browser-origin attacker can rebind an attacker-controlled hostname to the
+// victim's loopback address while preserving the browser Origin. Without
+// Host/Origin validation the browser can then complete an MCP session against
+// the local server and drive Kubernetes operations through the server-held
+// kubeconfig. The MCP specification requires servers that bind to localhost to
+// validate the Host and Origin headers for exactly this reason.
+//
+// The guard enforces two independent checks before any request reaches MCP
+// session handling:
+//
+//  1. Host allow-list. The request Host must be a loopback name, the configured
+//     bind host, or an explicitly allowed host.
+//  2. Origin allow-list. If an Origin header is present it must be explicitly
+//     allowed. A browser always sends Origin on cross-origin requests, so a
+//     rebinding page is rejected here.
+type hostOriginGuard struct {
+	next           http.Handler
+	allowedHosts   map[string]struct{}
+	allowedOrigin  map[string]struct{}
+	allowAnyHost   bool
+	allowAnyOrigin bool
+}
+
+// newHostOriginGuard builds the middleware. bindHost is the --host value the
+// server listens on; extraHosts / allowedOrigins are the operator-configured
+// comma-separated allow-lists. A "*" entry in either list disables that check.
+func newHostOriginGuard(next http.Handler, bindHost, extraHosts, allowedOrigins string) *hostOriginGuard {
+	g := &hostOriginGuard{
+		next:          next,
+		allowedHosts:  map[string]struct{}{},
+		allowedOrigin: map[string]struct{}{},
+	}
+
+	// Always-trusted loopback host names.
+	for _, h := range []string{"localhost", "127.0.0.1", "::1", "[::1]"} {
+		g.allowedHosts[h] = struct{}{}
+	}
+	if h := normalizeHost(bindHost); h != "" {
+		g.allowedHosts[h] = struct{}{}
+	}
+	for _, h := range splitList(extraHosts) {
+		if h == "*" {
+			g.allowAnyHost = true
+			continue
+		}
+		g.allowedHosts[normalizeHost(h)] = struct{}{}
+	}
+
+	for _, o := range splitList(allowedOrigins) {
+		if o == "*" {
+			g.allowAnyOrigin = true
+			continue
+		}
+		g.allowedOrigin[strings.ToLower(strings.TrimRight(o, "/"))] = struct{}{}
+	}
+
+	return g
+}
+
+func (g *hostOriginGuard) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !g.hostAllowed(r.Host) {
+		http.Error(w, "forbidden: Host header not allowed", http.StatusForbidden)
+		return
+	}
+	if origin := r.Header.Get("Origin"); origin != "" && !g.originAllowed(origin) {
+		http.Error(w, "forbidden: Origin header not allowed", http.StatusForbidden)
+		return
+	}
+	g.next.ServeHTTP(w, r)
+}
+
+func (g *hostOriginGuard) hostAllowed(host string) bool {
+	if g.allowAnyHost {
+		return true
+	}
+	_, ok := g.allowedHosts[normalizeHost(host)]
+	return ok
+}
+
+func (g *hostOriginGuard) originAllowed(origin string) bool {
+	if g.allowAnyOrigin {
+		return true
+	}
+	normalized := strings.ToLower(strings.TrimRight(strings.TrimSpace(origin), "/"))
+	if _, ok := g.allowedOrigin[normalized]; ok {
+		return true
+	}
+	// Accept loopback origins so a legitimate local client on the same host is
+	// not blocked, while a rebound attacker origin (a public hostname) is not.
+	if u, err := url.Parse(normalized); err == nil {
+		if host := u.Hostname(); isLoopbackHost(host) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeHost lowercases the host and strips any port, so "attacker:8084"
+// and "127.0.0.1:8084" compare against the bare host allow-list.
+func normalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.Trim(host, "[]")
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.Trim(strings.ToLower(host), "[]")
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+func splitList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/server/httpguard.go
+++ b/pkg/server/httpguard.go
@@ -22,9 +22,9 @@ import (
 //
 //  1. Host allow-list. The request Host must be a loopback name, the configured
 //     bind host, or an explicitly allowed host.
-//  2. Origin allow-list. If an Origin header is present it must be explicitly
-//     allowed. A browser always sends Origin on cross-origin requests, so a
-//     rebinding page is rejected here.
+//  2. Origin allow-list. If an Origin header is present it must be a loopback
+//     origin or an explicitly allowed origin. A browser always sends Origin on
+//     cross-origin requests, so a non-loopback rebinding page is rejected here.
 type hostOriginGuard struct {
 	next           http.Handler
 	allowedHosts   map[string]struct{}
@@ -47,7 +47,10 @@ func newHostOriginGuard(next http.Handler, bindHost, extraHosts, allowedOrigins 
 	for _, h := range []string{"localhost", "127.0.0.1", "::1", "[::1]"} {
 		g.allowedHosts[h] = struct{}{}
 	}
-	if h := normalizeHost(bindHost); h != "" {
+	// Trust the configured bind host, unless it is a wildcard address
+	// (0.0.0.0 / ::) which never appears as a client Host header — operators
+	// must list real hostnames via --allow-hosts in that case.
+	if h := normalizeHost(bindHost); h != "" && !isWildcardBindHost(h) {
 		g.allowedHosts[h] = struct{}{}
 	}
 	for _, h := range splitList(extraHosts) {
@@ -55,7 +58,9 @@ func newHostOriginGuard(next http.Handler, bindHost, extraHosts, allowedOrigins 
 			g.allowAnyHost = true
 			continue
 		}
-		g.allowedHosts[normalizeHost(h)] = struct{}{}
+		if nh := normalizeHost(h); nh != "" {
+			g.allowedHosts[nh] = struct{}{}
+		}
 	}
 
 	for _, o := range splitList(allowedOrigins) {
@@ -118,6 +123,16 @@ func normalizeHost(host string) string {
 		host = h
 	}
 	return strings.Trim(host, "[]")
+}
+
+// isWildcardBindHost reports whether host is an unspecified/wildcard bind
+// address (0.0.0.0 or ::). Such an address is never sent as a client Host
+// header, so it should not be added to the Host allow-list.
+func isWildcardBindHost(host string) bool {
+	if ip := net.ParseIP(strings.Trim(host, "[]")); ip != nil {
+		return ip.IsUnspecified()
+	}
+	return false
 }
 
 func isLoopbackHost(host string) bool {

--- a/pkg/server/httpguard_test.go
+++ b/pkg/server/httpguard_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestGuard(bindHost, extraHosts, allowedOrigins string) *hostOriginGuard {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return newHostOriginGuard(next, bindHost, extraHosts, allowedOrigins)
+}
+
+func doRequest(g *hostOriginGuard, host, origin string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Host = host
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	rr := httptest.NewRecorder()
+	g.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestHostOriginGuard_DNSRebindingBlocked(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "", "")
+
+	// The MSRC reproduction: attacker-controlled Host/Origin via DNS rebinding.
+	rr := doRequest(g, "attacker.example:8084", "http://attacker.example:8084")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected rebinding request to be forbidden, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_AttackerHostBlocked(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "", "")
+	// Host alone is enough to reject, even without an Origin header.
+	rr := doRequest(g, "attacker.example:8084", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected attacker Host to be forbidden, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_LoopbackAllowed(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "", "")
+	cases := []struct{ host, origin string }{
+		{"127.0.0.1:8084", ""},
+		{"localhost:8084", "http://localhost:8084"},
+		{"[::1]:8084", ""},
+		{"127.0.0.1:8084", "http://127.0.0.1:8084"},
+	}
+	for _, c := range cases {
+		rr := doRequest(g, c.host, c.origin)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected loopback host=%q origin=%q to be allowed, got %d", c.host, c.origin, rr.Code)
+		}
+	}
+}
+
+func TestHostOriginGuard_ConfiguredHostAllowed(t *testing.T) {
+	// Binding to a non-loopback address must still trust that host.
+	g := newTestGuard("10.0.0.5", "", "")
+	rr := doRequest(g, "10.0.0.5:8084", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected configured bind host to be allowed, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_ExtraAllowedHost(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "mcp.internal", "")
+	rr := doRequest(g, "mcp.internal:8084", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected explicitly allowed host to pass, got %d", rr.Code)
+	}
+	rr = doRequest(g, "other.internal:8084", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected non-allowed host to be forbidden, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_AllowedOrigin(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "", "https://app.example")
+	// Host must still be loopback; a trusted cross-origin caller is permitted.
+	rr := doRequest(g, "127.0.0.1:8084", "https://app.example")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected trusted origin to pass, got %d", rr.Code)
+	}
+	// Trailing slash normalized.
+	rr = doRequest(g, "127.0.0.1:8084", "https://app.example/")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected trusted origin with trailing slash to pass, got %d", rr.Code)
+	}
+	// A different origin is rejected even with a valid loopback Host.
+	rr = doRequest(g, "127.0.0.1:8084", "https://evil.example")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected untrusted origin to be forbidden, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_WildcardDisablesChecks(t *testing.T) {
+	g := newTestGuard("127.0.0.1", "*", "*")
+	rr := doRequest(g, "attacker.example:8084", "http://attacker.example:8084")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected wildcard config to allow any host/origin, got %d", rr.Code)
+	}
+}
+
+func TestHostOriginGuard_NoOriginHeaderAllowedForLoopback(t *testing.T) {
+	// Non-browser clients (no Origin) on a valid Host must not be blocked.
+	g := newTestGuard("127.0.0.1", "", "")
+	rr := doRequest(g, "localhost:8084", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected request without Origin to be allowed, got %d", rr.Code)
+	}
+}

--- a/pkg/server/httpguard_test.go
+++ b/pkg/server/httpguard_test.go
@@ -116,3 +116,30 @@ func TestHostOriginGuard_NoOriginHeaderAllowedForLoopback(t *testing.T) {
 		t.Fatalf("expected request without Origin to be allowed, got %d", rr.Code)
 	}
 }
+
+func TestHostOriginGuard_WildcardBindHostNotTrusted(t *testing.T) {
+	// Binding to 0.0.0.0/:: must not add the wildcard literal to the allow-list;
+	// a request whose Host is the wildcard literal is meaningless and rejected,
+	// while loopback still works.
+	for _, bind := range []string{"0.0.0.0", "::"} {
+		g := newTestGuard(bind, "", "")
+		if rr := doRequest(g, bind+":8084", ""); rr.Code != http.StatusForbidden {
+			t.Fatalf("bind=%q: expected wildcard Host to be forbidden, got %d", bind, rr.Code)
+		}
+		if rr := doRequest(g, "127.0.0.1:8084", ""); rr.Code != http.StatusOK {
+			t.Fatalf("bind=%q: expected loopback Host to still be allowed, got %d", bind, rr.Code)
+		}
+	}
+}
+
+func TestHostOriginGuard_MalformedAllowHostIgnored(t *testing.T) {
+	// A malformed --allow-hosts entry like ":8080" normalizes to "" and must
+	// not be added to the allow-list (which would let an empty Host through).
+	g := newTestGuard("127.0.0.1", ":8080", "")
+	if rr := doRequest(g, "", ""); rr.Code != http.StatusForbidden {
+		t.Fatalf("expected empty Host to be forbidden, got %d", rr.Code)
+	}
+	if rr := doRequest(g, "attacker.example:8080", ""); rr.Code != http.StatusForbidden {
+		t.Fatalf("expected attacker Host to be forbidden, got %d", rr.Code)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/Azure/mcp-kubernetes/pkg/cilium"
 	"github.com/Azure/mcp-kubernetes/pkg/config"
@@ -94,8 +95,9 @@ func (s *Service) Run() error {
 func (s *Service) serveHTTP(addr string, handler http.Handler) error {
 	guarded := newHostOriginGuard(handler, s.cfg.Host, s.cfg.AllowHosts, s.cfg.AllowOrigins)
 	httpServer := &http.Server{
-		Addr:    addr,
-		Handler: guarded,
+		Addr:              addr,
+		Handler:           guarded,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	return httpServer.ListenAndServe()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/Azure/mcp-kubernetes/pkg/cilium"
 	"github.com/Azure/mcp-kubernetes/pkg/config"
@@ -75,15 +76,28 @@ func (s *Service) Run() error {
 		sse := server.NewSSEServer(s.mcpServer)
 		addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 		log.Printf("SSE server listening on %s", addr)
-		return sse.Start(addr)
+		return s.serveHTTP(addr, sse)
 	case "streamable-http":
 		streamableServer := server.NewStreamableHTTPServer(s.mcpServer)
 		addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 		log.Printf("Streamable HTTP server listening on %s", addr)
-		return streamableServer.Start(addr)
+		return s.serveHTTP(addr, streamableServer)
 	default:
 		return fmt.Errorf("invalid transport type: %s (must be 'stdio', 'sse' or 'streamable-http')", s.cfg.Transport)
 	}
+}
+
+// serveHTTP wraps an MCP HTTP handler (streamable-http or sse) with the
+// Host/Origin guard and serves it. Guarding at the http.Handler layer ensures
+// attacker-origin requests are rejected before any MCP session handling,
+// defending against browser-origin DNS-rebinding attacks.
+func (s *Service) serveHTTP(addr string, handler http.Handler) error {
+	guarded := newHostOriginGuard(handler, s.cfg.Host, s.cfg.AllowHosts, s.cfg.AllowOrigins)
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: guarded,
+	}
+	return httpServer.ListenAndServe()
 }
 
 // registerKubectlCommands registers kubectl tools based on access level


### PR DESCRIPTION
The streamable-http and sse transports served the MCP handler without validating the Host or Origin request headers. Because the endpoint binds to loopback, a malicious web page can DNS-rebind an attacker-controlled hostname to 127.0.0.1 and drive MCP tool calls from the browser under the server-held kubeconfig.

Add a Host/Origin guard that wraps the MCP HTTP handler before any session handling. The request Host must be a loopback name, the configured --host, or an operator-listed host; a present Origin must be a loopback or trusted origin. New --allow-hosts and --allow-origins flags widen the allow-lists (with '*' to disable a check) for legitimate non-loopback deployments.